### PR TITLE
Adds code linting with flake8 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,10 @@ We are using [poetry][POET] to better manage dependency updates. To install
 
 `curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -`
 
+## Linting
+The [flake8][FLK8] Python code linter can be manually run by invoking `poetry run flake8` from
+the command-line. Configuration options are in the `setup.cfg` file, under the flake8 section.
+
 [AF]: https://airflow.apache.org/
+[FLK8]: https://flake8.pycqa.org/en/latest/
 [POET]: https://python-poetry.org/

--- a/dags/aws_sns.py
+++ b/dags/aws_sns.py
@@ -8,11 +8,11 @@ def SubscribeOperator(**kwargs) -> PythonOperator:
     """Subscribes to a topic to filter SQS messages"""
     topic = kwargs.get("topic", "")
     return PythonOperator(
-        task_id=f"subscribe-topic",
+        task_id=f"subscribe-topic-{topic}",
         python_callable=subscribe,
         op_kwargs={"topic": topic},
     )
 
 
 def subscribe(topic: str):
-    logging.info(f"Would subscribe to {topic} on AWS SNS")
+    logging.info(f"subscribe to {topic} on AWS SNS")

--- a/dags/folio.py
+++ b/dags/folio.py
@@ -1,6 +1,8 @@
 import logging
-from airflow.operators.bash import BashOperator
-from airflow.operators.python import PythonOperator
+
+# from airflow.operators.bash import BashOperator
+# from airflow.operators.python import PythonOperator
+
 
 def map_to_folio(urls: list):
     logging.info(f"Starting with {len(urls)} from Sinopia")

--- a/dags/sinopia.py
+++ b/dags/sinopia.py
@@ -1,8 +1,8 @@
 import logging
-import datetime
 from airflow.operators.python import PythonOperator
 from airflow.operators.bash import BashOperator
 from airflow.contrib.sensors.bash_sensor import BashSensor
+
 
 def UpdateIdentifier(**kwargs) -> PythonOperator:
     """Adds Identifier to Sinopia"""
@@ -46,18 +46,18 @@ def GitRdf2Marc() -> BashSensor:
     fi
     """
     return BashSensor(
-      task_id="git_rdf2marc",
-      bash_command=sensor_rdf2marc_cmd,
-      poke_interval=60,
-      timeout=60*50
+        task_id="git_rdf2marc",
+        bash_command=sensor_rdf2marc_cmd,
+        poke_interval=60,
+        timeout=60 * 50,
     )
+
 
 def Rdf2Marc(**kwargs) -> BashOperator:
     """Runs rdf2marc on a BF Instance URL"""
-    instance_url = kwargs.get('instance_url')
+    instance_url = kwargs.get("instance_url")
     if instance_url is None:
         raise ValueError("Missing Instance URL")
     return BashOperator(
-        task_id="rdf2marc",
-        bash_command=f"./exe/rdf2marc {instance_url}"
+        task_id="rdf2marc", bash_command=f"./exe/rdf2marc {instance_url}"
     )

--- a/dags/stanford.py
+++ b/dags/stanford.py
@@ -62,6 +62,8 @@ with DAG(
     # Retrive MARC from Sinopia API, convert to MARC JSON,
     setup_rdf2marc = GitRdf2Marc()
 
+    run_rdf2marc = Rdf2Marc(urls)
+
     sinopia_to_symphony_json = PythonOperator(
         task_id="symphony_json",
         python_callable=retrive_rdf2marc,
@@ -93,6 +95,6 @@ with DAG(
     update_sinopia = UpdateIdentifier(urls=urls)
 
 listen_sns >> branch_ils >> [setup_rdf2marc, sinopia_to_folio_records]
-setup_rdf2marc >> sinopia_to_symphony_json >> send_to_symphony >> processed_sinopia
+setup_rdf2marc >> run_rdf2marc >> sinopia_to_symphony_json >> send_to_symphony >> processed_sinopia
 sinopia_to_folio_records >> send_to_folio >> processed_sinopia
 processed_sinopia >> update_sinopia

--- a/dags/symphony.py
+++ b/dags/symphony.py
@@ -1,2 +1,2 @@
-import logging
-from airflow.operators.python import PythonOperator
+# import logging
+# from airflow.operators.python import PythonOperator

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,59 @@
+[[package]]
+name = "flake8"
+version = "3.9.2"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+mccabe = ">=0.6.0,<0.7.0"
+pycodestyle = ">=2.7.0,<2.8.0"
+pyflakes = ">=2.3.0,<2.4.0"
+
+[[package]]
+name = "mccabe"
+version = "0.6.1"
+description = "McCabe checker, plugin for flake8"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "pycodestyle"
+version = "2.7.0"
+description = "Python style guide checker"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pyflakes"
+version = "2.3.1"
+description = "passive checker of Python programs"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.9"
+content-hash = "2d46ac94f7180c4301a68946df9a72d3236c2e4a4813a197443e03242f32cf81"
+
+[metadata.files]
+flake8 = [
+    {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
+    {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
+]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
+    {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
+]
+pyflakes = [
+    {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
+    {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ license = "Apache2"
 python = "^3.9"
 
 [tool.poetry.dev-dependencies]
+flake8 = "^3.9.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Adds [flake8](https://flake8.pycqa.org/en/latest/) to development dependencies in poetry toml file. Also adds a new [poetry.lock](https://python-poetry.org/docs/libraries#lock-file) file that pins to specific versions for third party dependencies and is similar to concept with Ruby's `Gemfile.lock` file and Node's `package-lock.json` file. 

The DAG code files were refactor to pass linting and directions update in the README to manually run the linter.