### PR TITLE
Adds circle-ci configuration with lint and testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,44 @@
+version: 2.1
+
+orbs:
+  python: circleci/python@1.2
+
+workflows:
+  build:
+    jobs:
+      - build
+      - linting:
+          requires:
+            - build
+      - test:
+          requires:
+            - build
+
+jobs:
+  build:
+    docker:
+      - image: cimg/python:3.8
+    steps:
+      - checkout
+      - python/install-packages:
+          pkg-manager: poetry
+  linting:
+     executor: python/default
+     steps:
+      - checkout
+      - python/install-packages:
+          pkg-manager: poetry
+      - run:
+          name: Lint with flake8
+          command: |
+             poetry run flake8
+  test:
+      executor: python/default
+      steps:
+        - checkout
+        - python/install-packages:
+            pkg-manager: poetry
+        - run:
+            name: Run tests
+            command: |
+              poetry run pytest --version

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CircleCI](https://circleci.com/gh/LD4P/ils-middleware/tree/main.svg?style=svg)](https://circleci.com/gh/LD4P/ils-middleware/tree/main)
+
 # ILS Middleware
 Proof-of-concept for using [Apache Airflow][AF] to manage Sinopia workflows
 that interact with institutional integrated library systems (ILS) and/or

--- a/poetry.lock
+++ b/poetry.lock
@@ -260,8 +260,8 @@ python-versions = "*"
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.9"
-content-hash = "de11730b4d98c1a2f88bae0b687caa2fce9a25a8b8541d4eb08f6a60b6567978"
+python-versions = "^3.8"
+content-hash = "ddbae420d77856f0d837c5a3a9a26933a0a6a35ae25386e3b38f4c4e33c4e0f0"
 
 [metadata.files]
 atomicwrites = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Jeremy Nelson <jpnelson@stanford.edu>", "Aaron Collier <aaron.collie
 license = "Apache2"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.8"
 
 [tool.poetry.dev-dependencies]
 black = "21.8b0"


### PR DESCRIPTION
Will need to expand when deploying to AWS, for now just builds, runs flake8 and pytest.

Fixes #12 