### PR TITLE
initial version of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM apache/airflow:2.1.2-python3.8
+
+USER root
+RUN apt-get -y update && apt-get -y install git
+USER airflow
+
+COPY --chown=airflow:root ./dags /opt/airflow/dags


### PR DESCRIPTION
closes #21 

per the issue, this just copypastas https://github.com/sul-dlss/dlme-airflow/blob/main/Dockerfile, minus its intake catalog `COPY`, and with a bit of adjustment to the other `COPY`.  i'm unsure i did that last part correctly -- e.g. i tried to do the equivalent of dlme-airflow's copy of the `dlme_airflow` dir, which contains the `dags` dir.  in this case, that meant i just did a `COPY` on the `dags` dir, since it's right in the project root.  should other things (e.g. `pyproject.toml`, `poetry.lock`) have been copied into the image too?