### PR TITLE
Update docker compose command from deprecated docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Based on the documentation, [Running Airflow in Docker](https://airflow.apache.o
 
 1. Clone repository `git clone https://github.com/LD4P/ils-middleware`
 1. If it's commented out, uncomment the line `- ./dags:/opt/airflow/dags` in docker-compose.yaml (under `volumes`, under `x-airflow-common`).
-1. Run `docker-compose up airflow-init` to initialize the Airflow
-1. Bring up airflow, `docker-compose up` to run the containers in the foreground,
-   add `docker-compose up -d` to run as a daemon.
+1. Run `docker compose up airflow-init` to initialize the Airflow
+1. Bring up airflow, `docker compose up` to run the containers in the foreground,
+   add `docker compose up -d` to run as a daemon.
 1. Access Airflow locally at http://localhost:8080
 
 ## Editing existing DAGs


### PR DESCRIPTION
Update the readme to reflect the non-deprecated `docker compose` command instead of `docker-compose`.