### PR TITLE
SymphonyLogin Task 

### DIFF
--- a/dags/symphony.py
+++ b/dags/symphony.py
@@ -1,3 +1,29 @@
 """Supporting Functions and Operators for Symphony."""
-# import logging
-# from airflow.operators.python import PythonOperator
+import json
+
+from airflow.providers.http.operators.http import SimpleHttpOperator
+
+
+def SymphonyLogin(**kwargs) -> SimpleHttpOperator:
+
+    app_id = kwargs.get("app_id")
+    client_id = kwargs.get("client_id")
+    conn_id = kwargs.get("conn_id")
+    dag = kwargs.get("dag")
+    login = kwargs.get("login")
+    password = kwargs.get("password")
+
+    return SimpleHttpOperator(
+        task_id="symphony_login",
+        http_conn_id=conn_id,
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "SD-originating-app-id": app_id,
+            "x-sirs-clientID": client_id,
+        },
+        endpoint="user/staff/login",
+        response_filter=lambda response: response.json().get("sessionToken"),
+        dag=dag,
+        data=json.dumps({"login": login, "password": password}),
+    )

--- a/tests/test_symphony.py
+++ b/tests/test_symphony.py
@@ -1,0 +1,31 @@
+"""Test Symphony Operators and functions."""
+
+import pytest
+
+from datetime import datetime
+
+from airflow import DAG
+
+from dags.symphony import SymphonyLogin
+
+
+@pytest.fixture
+def test_dag():
+    start_date = datetime(2021, 9, 20)
+    return DAG("test_dag", default_args={"owner": "airflow", "start_date": start_date})
+
+
+def test_subscribe_operator_missing_kwargs(test_dag):
+    """Test missing kwargs for SubscribeOperator."""
+
+    task = SymphonyLogin(dag=test_dag)
+    assert task.http_conn_id is None
+
+
+def test_subscribe_operator(test_dag):
+    """Test with typical kwargs for SubscribeOperator."""
+    task = SymphonyLogin(
+        conn_id="symphony_dev_login", login="DEVSYS", password="APASSWord", dag=test_dag
+    )
+    assert task.http_conn_id.startswith("symphony_dev_login")
+    assert "DEVSYS" in task.data


### PR DESCRIPTION
Fixes #10 

To use in a DAG

```python
from symphony import SymphonyLogin

from airflow import DAG
with DAG(
 ...
) as dag:
 .
 .
 .
    symphony_token = SymphonyLogin(app_id="SINOPIA_DEV",
        client_id="SymWSStaffClient",
        conn_id="symphony_dev",
        login=Variable.get('stanford_symphony_dev'),
        password=Variable.get('stanford_symphony_dev_password'))
```
The `SymphonyLogin` returns a `sessionToken` value that is required for subsequent Symphony calls. The Symphony login and password are retrieve from Airflow Variables that should eventually be extracted from the Secrets Vault. You must also set-up a Symphony Airflow Connection (in the example above `symphony_dev`) that has been added to the [wiki](https://github.com/LD4P/ils-middleware/wiki/Symphony-ILS-in-Airflow). 

**NOTE**: This PR is in draft and fails until PR [38](https://github.com/LD4P/ils-middleware/pull/38) is merged that includes the Airflow poetry installation. 