### PR TITLE
Adds new task for parsing SQS Message

### DIFF
--- a/ils_middleware/tasks/sinopia/rdf2marc.py
+++ b/ils_middleware/tasks/sinopia/rdf2marc.py
@@ -8,8 +8,7 @@ from airflow.contrib.hooks.aws_lambda_hook import AwsLambdaHook
 
 def Rdf2Marc(**kwargs):
     """Runs rdf2marc on a BF Instance URL"""
-    task_instance = kwargs["task_instance"]
-    instance_uri = task_instance.xcom_pull(task_ids="sqs-sensor")
+    instance_uri = kwargs.get("instance_uri")
 
     instance_path = urlparse(instance_uri).path
     instance_id = path.split(instance_path)[-1]

--- a/tests/tasks/sinopia/test_rdf2marc.py
+++ b/tests/tasks/sinopia/test_rdf2marc.py
@@ -41,9 +41,10 @@ def mock_lambda(monkeypatch):
 
 def test_Rdf2Marc(mock_task_instance, mock_lambda):
     payload = {"instance_uri": "http://example.com/rdf/0000-1111-2222-3333"}
-    execution_date = datetime(2021, 9, 21)
-    task_instance = TaskInstance(test_task(), execution_date)
 
     assert (
-        Rdf2Marc(task_instance=task_instance, payload=payload) == "0000-1111-2222-3333"
+        Rdf2Marc(
+            instance_uri="http://example.com/rdf/0000-1111-2222-3333", payload=payload
+        )
+        == "0000-1111-2222-3333"
     )


### PR DESCRIPTION
Fixes #62
Blocks #71 

Downstream tasks can now extract `email` and `resource_uri` from the task's XCOM. Also retrieves the resource's group and adds to XCOM. 

