### PR TITLE
Symphony functions as Python callables

### DIFF
--- a/ils_middleware/tasks/symphony/login.py
+++ b/ils_middleware/tasks/symphony/login.py
@@ -2,10 +2,9 @@
 import json
 
 from ils_middleware.tasks.symphony.request import SymphonyRequest
-from airflow.providers.http.operators.http import SimpleHttpOperator
 
 
-def SymphonyLogin(**kwargs) -> SimpleHttpOperator:
+def SymphonyLogin(**kwargs) -> str:
     login = kwargs.get("login")
     password = kwargs.get("password")
 

--- a/ils_middleware/tasks/symphony/mod_json.py
+++ b/ils_middleware/tasks/symphony/mod_json.py
@@ -14,6 +14,7 @@ def _get_subfields(subfields: dict) -> list:
 
 def _get_variable_field(value, new_field):
     if "ind1" in value:
+
         new_field["inds"] = "".join([value["ind1"], value["ind2"]])
     new_field["subfields"] = []
     for row in value["subfields"]:
@@ -40,5 +41,5 @@ def to_symphony_json(**kwargs):
     record["leader"] = pymarc_json.get("leader")
     for field in pymarc_json["fields"]:
         record["fields"].append(_get_fields(field))
-    logger.debug("Converted pymarc json to Symphony JSON")
-    return json.dumps(record)
+
+    return record

--- a/ils_middleware/tasks/symphony/new.py
+++ b/ils_middleware/tasks/symphony/new.py
@@ -1,16 +1,18 @@
 """New Record in Symphony"""
+import ast
 import json
 
 from ils_middleware.tasks.symphony.request import SymphonyRequest
-from airflow.providers.http.operators.http import SimpleHttpOperator
 
 
-def NewMARCtoSymphony(**kwargs) -> SimpleHttpOperator:
+def NewMARCtoSymphony(**kwargs) -> str:
     """Creates a new record in Symphony and returns the new CatKey"""
-    marc_json = kwargs.get("marc_json")
+    marc_json = kwargs.get("marc_json", "")
     library_key = kwargs.get("library_key")
     item_type = kwargs.get("item_type")
     home_location = kwargs.get("home_location")
+
+    marc_json = ast.literal_eval(marc_json)
 
     payload = {
         "@resource": "/catalog/bib",
@@ -43,7 +45,6 @@ def NewMARCtoSymphony(**kwargs) -> SimpleHttpOperator:
 
     return SymphonyRequest(
         **kwargs,
-        task_id="post_new_symphony",
         data=json.dumps(payload),
         endpoint="catalog/bib",
         filter=lambda response: response.json().get("@key"),

--- a/tests/tasks/symphony/test_mod_json.py
+++ b/tests/tasks/symphony/test_mod_json.py
@@ -35,9 +35,7 @@ def org_json():
 
 
 def test_to_symphony_json(org_json):
-    json_str = json.dumps(org_json)
-    result = to_symphony_json(marc_json=json_str)
-    symphony_json = json.loads(result)
+    symphony_json = to_symphony_json(marc_json=json.dumps(org_json))
     assert symphony_json["standard"].startswith("MARC21")
     assert symphony_json["leader"].startswith("01176nam a2200241uu 4500")
     assert symphony_json["fields"][0]["tag"] == "008"

--- a/tests/tasks/symphony/test_new.py
+++ b/tests/tasks/symphony/test_new.py
@@ -1,27 +1,67 @@
 """Tests new MARC record in Symphony task."""
 
-from datetime import datetime
-import pytest
 
-from airflow import DAG
+import pytest
+import requests  # type: ignore
+
+from airflow.hooks.base_hook import BaseHook
+from pytest_mock import MockerFixture
+
 from ils_middleware.tasks.symphony.new import NewMARCtoSymphony
 
 
 @pytest.fixture
-def test_dag():
-    start_date = datetime(2021, 9, 20)
-    return DAG("test_dag", default_args={"owner": "airflow", "start_date": start_date})
+def mock_connection(monkeypatch, mocker: MockerFixture):
+    def mock_get_connection(*args, **kwargs):
+        connection = mocker.stub(name="Connection")
+        connection.host = "https://symphony.test.edu/"
+
+        return connection
+
+    monkeypatch.setattr(BaseHook, "get_connection", mock_get_connection)
 
 
-def test_NewMARCtoSymphony(test_dag):
+@pytest.fixture
+def mock_new_request(monkeypatch, mocker: MockerFixture):
+    def mock_post(*args, **kwargs):
+        new_result = mocker.stub(name="post_result")
+        new_result.token = "234566"
+        new_result.status_code = 200
+        new_result.text = "Successful creation"
+        new_result.json = lambda: {"@key": "45678"}
+        return new_result
+
+    monkeypatch.setattr(requests, "post", mock_post)
+
+
+def test_NewMARCtoSymphony(mock_connection, mock_new_request):
     """Tests NewMARCtoSymphony"""
-    task = NewMARCtoSymphony(
+    task_result = NewMARCtoSymphony(
         conn_id="symphony_dev_login",
-        session_token="abcdefag",
+        session_token="abcde4590",
         library_key="GREEN",
-        marc_json={"leader": "basdfdaf   adf", "fields": [{"tag": "245"}]},
-        dag=test_dag,
+        marc_json="""{"leader": "11222999   adf", "fields": [{"tag": "245"}]}""",
     )
-    assert task.http_conn_id.startswith("symphony_dev_login")
-    assert task.endpoint.startswith("catalog/bib")
-    assert "basdfdaf" in task.data
+    assert "45678" == task_result
+
+
+@pytest.fixture
+def mock_failed_request(monkeypatch, mocker: MockerFixture):
+    def mock_failed_post(*args, **kwargs):
+        failed_result = mocker.stub(name="post_result")
+        failed_result.status_code = 401
+        failed_result.text = "Unauthorized"
+        return failed_result
+
+    monkeypatch.setattr(requests, "post", mock_failed_post)
+
+
+def test_NewMARCtoSymphony_failed(mock_connection, mock_failed_request):
+    """Test failed NewMARCtoSymphony"""
+    with pytest.raises(Exception, match="Symphony Web Service"):
+        NewMARCtoSymphony(
+            conn_id="symphony_dev_login",
+            session_token="abcde3456",
+            library_key="GREEN",
+            marc_json="""{"leader": "11222999   adf", "fields": [{"tag": "245"}]}""",
+        )

--- a/tests/tasks/symphony/test_symphony_request.py
+++ b/tests/tasks/symphony/test_symphony_request.py
@@ -1,12 +1,11 @@
-"""Test Symphony Login."""
-
+"""Tests Symphony Request"""
 import pytest
 import requests  # type: ignore
 
 from airflow.hooks.base_hook import BaseHook
 from pytest_mock import MockerFixture
 
-from ils_middleware.tasks.symphony.login import SymphonyLogin
+from ils_middleware.tasks.symphony.request import SymphonyRequest
 
 
 @pytest.fixture
@@ -21,22 +20,17 @@ def mock_connection(monkeypatch, mocker: MockerFixture):
 
 
 @pytest.fixture
-def mock_login_request(monkeypatch, mocker: MockerFixture):
+def mock_request(monkeypatch, mocker: MockerFixture):
     def mock_post(*args, **kwargs):
         new_result = mocker.stub(name="post_result")
         new_result.status_code = 200
-        new_result.text = "Successful login"
-        new_result.json = lambda: {"sessionToken": "234566"}
+        new_result.text = "Successful request"
+        new_result.json = lambda: {}
         return new_result
 
     monkeypatch.setattr(requests, "post", mock_post)
 
 
-def test_subscribe_operator(mock_connection, mock_login_request):
-    """Test with typical kwargs for SymphonyLogin."""
-    task_login = SymphonyLogin(
-        conn_id="symphony_dev_login",
-        login="DEVSYS",
-        password="APASSWord",
-    )
-    assert task_login == "234566"
+def test_missing_request_filter(mock_connection, mock_request):
+    result = SymphonyRequest(token="34567")
+    assert result.startswith("Successful request")


### PR DESCRIPTION
Refactor Symphony functions running as python functions using PythonOperators. Previous versions did not accept templated functions to pass necessary XCOM variables. Possible future refactor would be to extend the existing `SimpleHTTPOperator`. 