### PR TITLE
Refactor Stanford DAG to utilize multiple sqs messages

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,14 +1,15 @@
 # placing this in the root allows the tests in the 'tests' directory to import the packages in the root, e.g. 'dags'
 import pathlib
 import sys
-import os
 
 import pytest
 import rdflib
 
-rdf_file = pathlib.Path(__file__).parent / "tests" / "fixtures" / "bf.ttl"
+root_dir = pathlib.Path(__file__).parent
+rdf_file = root_dir / "tests" / "fixtures" / "bf.ttl"
+helpers = root_dir / "tests" / "helpers"
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "tests/helpers"))
+sys.path.append(str(helpers))
 
 
 @pytest.fixture

--- a/conftest.py
+++ b/conftest.py
@@ -1,10 +1,14 @@
 # placing this in the root allows the tests in the 'tests' directory to import the packages in the root, e.g. 'dags'
 import pathlib
+import sys
+import os
 
 import pytest
 import rdflib
 
 rdf_file = pathlib.Path(__file__).parent / "tests" / "fixtures" / "bf.ttl"
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "tests/helpers"))
 
 
 @pytest.fixture

--- a/ils_middleware/dags/stanford.py
+++ b/ils_middleware/dags/stanford.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from airflow import DAG
 from airflow.models import Variable
 from airflow.operators.dummy import DummyOperator
-from airflow.operators.python import BranchPythonOperator, PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.utils.task_group import TaskGroup
 
 from ils_middleware.tasks.amazon.s3 import get_from_s3, send_to_s3
@@ -69,25 +69,16 @@ with DAG(
         download_marc = PythonOperator(
             task_id="download_marc",
             python_callable=get_from_s3,
-            op_kwargs={
-                "instance_id": "{{ task_instance.xcom_pull(task_ids='process_symphony.rdf2marc', key='return_value') }}"
-            },
         )
 
         export_marc_json = PythonOperator(
             task_id="marc_json_to_s3",
             python_callable=send_to_s3,
-            op_kwargs={
-                "instance": "{{ task_instance.xcom_pull(task_ids='process_symphony.download_marc', key='return_value') }}"
-            },
         )
 
         convert_to_symphony_json = PythonOperator(
             task_id="convert_to_symphony_json",
             python_callable=to_symphony_json,
-            op_kwargs={
-                "marc_json": "{{ task_instance.xcom_pull(task_ids='process_symphony.marc_json_to_s3', key='return_value') }}"
-            },
         )
 
         # Symphony Dev Server Settings
@@ -111,16 +102,9 @@ with DAG(
             },
         )
 
-        new_or_overlay = BranchPythonOperator(
+        new_or_overlay = PythonOperator(
             task_id="new-or-overlay",
             python_callable=existing_metadata_check,
-            op_kwargs={
-                "resource_uri": "{{ task_instance.xcom_pull(task_ids='sqs-message-parse', key='resource_uri') }}",
-                "ils_tasks": {
-                    "new": "process_symphony.post_new_symphony",
-                    "overlay": "process_symphony.post_overlay_symphony",
-                },
-            },
         )
 
         symphony_add_record = PythonOperator(
@@ -133,8 +117,6 @@ with DAG(
                 "home_location": home_location,
                 "item_type": symphony_item_type,
                 "library_key": library_key,
-                "marc_json": """{{ task_instance.xcom_pull(key='return_value',
-                                      task_ids='process_symphony.convert_to_symphony_json')}}""",
                 "token": "{{ task_instance.xcom_pull(key='return_value', task_ids='process_symphony.symphony-login')}}",
             },
         )
@@ -144,11 +126,8 @@ with DAG(
             python_callable=overlay_marc_in_symphony,
             op_kwargs={
                 "app_id": symphony_app_id,
-                "catkey": "{{ task_instance.xcom_pull(key='SIRSI', task_ids='process_symphony.new-or-overlay') }}",
                 "client_id": symphony_client_id,
                 "conn_id": symphony_conn_id,
-                "marc_json": """{{ task_instance.xcom_pull(key='return_value',
-                                   task_ids='process_symphony.convert_to_symphony_json')}}""",
                 "token": "{{ task_instance.xcom_pull(key='return_value', task_ids='process_symphony.symphony-login')}}",
             },
         )
@@ -195,8 +174,6 @@ with DAG(
             python_callable=new_local_admin_metadata,
             op_kwargs={
                 "jwt": "{{ task_instance.xcom_pull(task_ids='update_sinopia.sinopia-login', key='return_value') }}",
-                "resource": "{{ task_instance.xcom_pull(task_ids='sqs-message-parse', key='resource') }}",
-                "instance_uri": "{{ task_instance.xcom_pull(task_ids='sqs-message-parse', key='resource_uri') }}",
                 "ils_identifiers": {
                     "SIRSI": """{{ task_instance.xcom_pull(task_ids='process_symphony.post_new_symphony', key='return_value') or task_instance.xcom_pull(task_ids='process_symphony.post_overlay_symphony', key='return_value') }}"""  # noqa: E501
                 },
@@ -209,8 +186,6 @@ with DAG(
             python_callable=update_resource_new_metadata,
             op_kwargs={
                 "jwt": "{{ task_instance.xcom_pull(task_ids='update_sinopia.sinopia-login', key='return_value') }}",
-                "resource_uri": "{{ task_instance.xcom_pull(task_ids='sqs-message-parse', key='resource_uri') }}",
-                "metadata_uri": "{{task_instance.xcom_pull(task_ids='update_sinopia.sinopia-new-metadata', key='return_value')}}",
             },
         )
 

--- a/ils_middleware/dags/stanford.py
+++ b/ils_middleware/dags/stanford.py
@@ -61,9 +61,8 @@ with DAG(
             task_id="rdf2marc",
             python_callable=Rdf2Marc,
             op_kwargs={
-                "instance_uri": "{{ task_instance.xcom_pull(task_ids='sqs-message-parse', key='resource_uri') }}",
-                "rdf2marc_lambda": Variable.get("rdf2marc_lambda"),
-                "s3_bucket": Variable.get("marc_s3_bucket"),
+                "rdf2marc_lambda": "sinopia-rdf2marc-development",
+                "s3_bucket": "sinopia-marc-development",
             },
         )
 

--- a/ils_middleware/tasks/amazon/s3.py
+++ b/ils_middleware/tasks/amazon/s3.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from urllib.parse import urlparse
 import os
@@ -32,7 +31,9 @@ def send_to_s3(**kwargs) -> dict:
     for instance_uri in resources:
         instance_path = urlparse(instance_uri).path
         instance_id = path.split(instance_path)[-1]
-        temp_file = task_instance.xcom_pull(key=instance_uri, task_ids=["process_symphony.download_marc"])
+        temp_file = task_instance.xcom_pull(
+            key=instance_uri, task_ids=["process_symphony.download_marc"]
+        )
         marc_record = marc_record_from_temp_file(instance_id, temp_file)
         s3_hook.load_string(
             marc_record.as_json(),

--- a/ils_middleware/tasks/amazon/s3.py
+++ b/ils_middleware/tasks/amazon/s3.py
@@ -34,15 +34,13 @@ def send_to_s3(**kwargs) -> dict:
         instance_id = path.split(instance_path)[-1]
         temp_file = task_instance.xcom_pull(key=instance_uri, task_ids=["process_symphony.download_marc"])
         marc_record = marc_record_from_temp_file(instance_id, temp_file)
-
         s3_hook.load_string(
             marc_record.as_json(),
             f"marc/airflow/{instance_id}/record.json",
             "sinopia-marc-development",
             replace=True,
         )
-
-    return marc_record.as_json()
+        task_instance.xcom_push(key=instance_uri, value=marc_record.as_json())
 
 
 def marc_record_from_temp_file(instance_id, temp_file):
@@ -51,4 +49,3 @@ def marc_record_from_temp_file(instance_id, temp_file):
             return next(MARCReader(marc))
     else:
         logger.error(f"MARC data for {instance_id} missing or empty.")
-        # raise Exception()

--- a/ils_middleware/tasks/amazon/s3.py
+++ b/ils_middleware/tasks/amazon/s3.py
@@ -1,4 +1,5 @@
 import logging
+import ast
 from urllib.parse import urlparse
 import os
 from os import path
@@ -11,7 +12,9 @@ logger = logging.getLogger(__name__)
 def get_from_s3(**kwargs):
     s3_hook = S3Hook(aws_conn_id="aws_lambda_connection")
     task_instance = kwargs.get("task_instance")
-    resources = task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])
+    resources = ast.literal_eval(
+        task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])
+    )
 
     for instance_uri in resources:
         instance_path = urlparse(instance_uri).path
@@ -27,7 +30,9 @@ def get_from_s3(**kwargs):
 def send_to_s3(**kwargs):
     s3_hook = S3Hook(aws_conn_id="aws_lambda_connection")
     task_instance = kwargs.get("task_instance")
-    resources = task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])
+    resources = ast.literal_eval(
+        task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])
+    )
     for instance_uri in resources:
         instance_path = urlparse(instance_uri).path
         instance_id = path.split(instance_path)[-1]

--- a/ils_middleware/tasks/amazon/s3.py
+++ b/ils_middleware/tasks/amazon/s3.py
@@ -8,7 +8,7 @@ from pymarc import MARCReader
 logger = logging.getLogger(__name__)
 
 
-def get_from_s3(**kwargs) -> str:
+def get_from_s3(**kwargs):
     s3_hook = S3Hook(aws_conn_id="aws_lambda_connection")
     task_instance = kwargs.get("task_instance")
     resources = task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])
@@ -24,7 +24,7 @@ def get_from_s3(**kwargs) -> str:
         task_instance.xcom_push(key=instance_uri, value=temp_file)
 
 
-def send_to_s3(**kwargs) -> dict:
+def send_to_s3(**kwargs):
     s3_hook = S3Hook(aws_conn_id="aws_lambda_connection")
     task_instance = kwargs.get("task_instance")
     resources = task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])

--- a/ils_middleware/tasks/amazon/s3.py
+++ b/ils_middleware/tasks/amazon/s3.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from urllib.parse import urlparse
+import os
 from os import path
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from pymarc import MARCReader
@@ -26,13 +27,17 @@ def get_from_s3(**kwargs) -> str:
 
 def send_to_s3(**kwargs) -> dict:
     s3_hook = S3Hook(aws_conn_id="aws_lambda_connection")
-    instances = kwargs.get("instances")
-    for instance in instances:
-        marc_record = marc_record_from_temp_file(instance)
+    task_instance = kwargs.get("task_instance")
+    resources = task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])
+    for instance_uri in resources:
+        instance_path = urlparse(instance_uri).path
+        instance_id = path.split(instance_path)[-1]
+        temp_file = task_instance.xcom_pull(key=instance_uri, task_ids=["process_symphony.download_marc"])
+        marc_record = marc_record_from_temp_file(instance_id, temp_file)
 
         s3_hook.load_string(
             marc_record.as_json(),
-            f"marc/airflow/{instance['id']}/record.json",
+            f"marc/airflow/{instance_id}/record.json",
             "sinopia-marc-development",
             replace=True,
         )
@@ -40,12 +45,10 @@ def send_to_s3(**kwargs) -> dict:
     return marc_record.as_json()
 
 
-def marc_record_from_temp_file(instance):
-    instance_id = instance["id"]
-    temp_file = instance["temp_file"]
+def marc_record_from_temp_file(instance_id, temp_file):
     if os.path.exists(temp_file) and os.path.getsize(temp_file) > 0:
         with open(temp_file, "rb") as marc:
             return next(MARCReader(marc))
     else:
         logger.error(f"MARC data for {instance_id} missing or empty.")
-        raise Exception()
+        # raise Exception()

--- a/ils_middleware/tasks/amazon/sqs.py
+++ b/ils_middleware/tasks/amazon/sqs.py
@@ -36,7 +36,7 @@ def get_resource(resource_uri: str) -> dict:
 def parse_messages(**kwargs) -> str:
     """Parses SQS Message Body into constituent part."""
     task_instance = kwargs["task_instance"]
-    raw_sqs_messages = task_instance.xcom_pull(key="messages", task_ids=["sqs-sensor"])
+    raw_sqs_messages = task_instance.xcom_pull(key="messages", task_ids="sqs-sensor")
 
     resources = []
     for message in raw_sqs_messages:

--- a/ils_middleware/tasks/amazon/sqs.py
+++ b/ils_middleware/tasks/amazon/sqs.py
@@ -43,8 +43,10 @@ def parse_messages(**kwargs) -> str:
         message = message[0]
         message_body = json.loads(message.get("Body"))
         resource_uri = message_body["resource"]["uri"]
-        resources.append(
-            {
+        resources.append(resource_uri)
+        task_instance.xcom_push(
+            key=resource_uri,
+            value={
                 "email": message_body["user"]["email"],
                 "resource_uri": resource_uri,
                 "resource": get_resource(resource_uri),

--- a/ils_middleware/tasks/amazon/sqs.py
+++ b/ils_middleware/tasks/amazon/sqs.py
@@ -21,7 +21,7 @@ def SubscribeOperator(**kwargs) -> SQSSensor:
         sqs_queue=f"{aws_sqs_url}{queue_name}",
         task_id="sqs-sensor",
         dag=kwargs.get("dag"),
-        max_messages=50,
+        max_messages=10,
     )
 
 

--- a/ils_middleware/tasks/amazon/sqs.py
+++ b/ils_middleware/tasks/amazon/sqs.py
@@ -50,7 +50,7 @@ def parse_messages(**kwargs) -> str:
                 "email": message_body["user"]["email"],
                 "resource_uri": resource_uri,
                 "resource": get_resource(resource_uri),
-            }
+            },
         )
 
     task_instance.xcom_push(key="resources", value=resources)

--- a/ils_middleware/tasks/sinopia/local_metadata.py
+++ b/ils_middleware/tasks/sinopia/local_metadata.py
@@ -88,7 +88,7 @@ def new_local_admin_metadata(*args, **kwargs) -> str:
 
         admin_metadata_uri = f"{sinopia_api_uri}/{uuid.uuid4()}"
         local_metadata_rdf = create_admin_metadata(
-            **kwargs, admin_metadata_uri=admin_metadata_uri
+            **kwargs, instance_uri=resource_uri, admin_metadata_uri=admin_metadata_uri
         )
 
         local_metadata_rdf = json.loads(local_metadata_rdf)

--- a/ils_middleware/tasks/sinopia/local_metadata.py
+++ b/ils_middleware/tasks/sinopia/local_metadata.py
@@ -67,7 +67,7 @@ def create_admin_metadata(**kwargs) -> str:
     return graph.serialize(format="json-ld")
 
 
-def new_local_admin_metadata(*args, **kwargs) -> str:
+def new_local_admin_metadata(*args, **kwargs):
     "Add Identifier to Sinopia localAdminMetadata."
     task_instance = kwargs["task_instance"]
     resources = task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])

--- a/ils_middleware/tasks/sinopia/local_metadata.py
+++ b/ils_middleware/tasks/sinopia/local_metadata.py
@@ -80,9 +80,8 @@ def new_local_admin_metadata(*args, **kwargs) -> str:
 
     admin_metadata = []
 
-    for instance in resources:
-        resource_uri = instance["resource_uri"]
-        resource = instance["resource"]
+    for resource_uri in resources:
+        resource = task_instance.xcom_pull(key=resource_uri, task_ids=["sqs-message-parse"])
         group = resource.get("group")
         editGroups = resource.get("editGroups", [])
 

--- a/ils_middleware/tasks/sinopia/local_metadata.py
+++ b/ils_middleware/tasks/sinopia/local_metadata.py
@@ -3,6 +3,7 @@ import json
 import datetime
 import logging
 import uuid
+import ast
 
 import rdflib
 import requests  # type: ignore
@@ -70,16 +71,17 @@ def create_admin_metadata(**kwargs) -> str:
 def new_local_admin_metadata(*args, **kwargs):
     "Add Identifier to Sinopia localAdminMetadata."
     task_instance = kwargs["task_instance"]
-    resources = task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])
+    resources = ast.literal_eval(
+        task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])
+    )
     jwt = kwargs.get("jwt")
-    sinopia_env = kwargs.get("sinopia_env", "dev")
     user = Variable.get("sinopia_user")
     kwargs["cataloger_id"] = user
-    sinopia_api_uri = Variable.get(f"{sinopia_env}_sinopia_api_uri")
+    sinopia_api_uri = Variable.get("sinopia_api_uri")
 
     for resource_uri in resources:
-        resource = task_instance.xcom_pull(
-            key=resource_uri, task_ids=["sqs-message-parse"]
+        resource = ast.literal_eval(
+            task_instance.xcom_pull(key=resource_uri, task_ids=["sqs-message-parse"])
         )
         group = resource.get("group")
         editGroups = resource.get("editGroups", [])

--- a/ils_middleware/tasks/sinopia/local_metadata.py
+++ b/ils_middleware/tasks/sinopia/local_metadata.py
@@ -1,5 +1,4 @@
 """Adds Sinopia localAdminMetadata record."""
-import ast
 import json
 import datetime
 import logging
@@ -78,10 +77,10 @@ def new_local_admin_metadata(*args, **kwargs) -> str:
     kwargs["cataloger_id"] = user
     sinopia_api_uri = Variable.get(f"{sinopia_env}_sinopia_api_uri")
 
-    admin_metadata = []
-
     for resource_uri in resources:
-        resource = task_instance.xcom_pull(key=resource_uri, task_ids=["sqs-message-parse"])
+        resource = task_instance.xcom_pull(
+            key=resource_uri, task_ids=["sqs-message-parse"]
+        )
         group = resource.get("group")
         editGroups = resource.get("editGroups", [])
 
@@ -123,6 +122,4 @@ def new_local_admin_metadata(*args, **kwargs) -> str:
             raise Exception(msg)
 
         logger.debug(f"Results of new_admin_result {new_admin_result.text}")
-        # admin_metadata.append(admin_metadata_uri)
         task_instance.xcom_push(key=resource_uri, value=admin_metadata_uri)
-    # task_instance.xcom_push(key="admin_metadata", value=admin_metadata)

--- a/ils_middleware/tasks/sinopia/local_metadata.py
+++ b/ils_middleware/tasks/sinopia/local_metadata.py
@@ -71,9 +71,8 @@ def create_admin_metadata(**kwargs) -> str:
 def new_local_admin_metadata(*args, **kwargs):
     "Add Identifier to Sinopia localAdminMetadata."
     task_instance = kwargs["task_instance"]
-    resources = ast.literal_eval(
-        task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])
-    )
+    resources = task_instance.xcom_pull(key="resources", task_ids="sqs-message-parse")
+
     jwt = kwargs.get("jwt")
     user = Variable.get("sinopia_user")
     kwargs["cataloger_id"] = user
@@ -81,7 +80,7 @@ def new_local_admin_metadata(*args, **kwargs):
 
     for resource_uri in resources:
         resource = ast.literal_eval(
-            task_instance.xcom_pull(key=resource_uri, task_ids=["sqs-message-parse"])
+            task_instance.xcom_pull(key=resource_uri, task_ids="sqs-message-parse")
         )
         group = resource.get("group")
         editGroups = resource.get("editGroups", [])

--- a/ils_middleware/tasks/sinopia/local_metadata.py
+++ b/ils_middleware/tasks/sinopia/local_metadata.py
@@ -123,6 +123,6 @@ def new_local_admin_metadata(*args, **kwargs) -> str:
             raise Exception(msg)
 
         logger.debug(f"Results of new_admin_result {new_admin_result.text}")
-        admin_metadata.append(admin_metadata_uri)
-
-    task_instance.xcom_push(key="admin_metadata", value=admin_metadata)
+        # admin_metadata.append(admin_metadata_uri)
+        task_instance.xcom_push(key=resource_uri, value=admin_metadata_uri)
+    # task_instance.xcom_push(key="admin_metadata", value=admin_metadata)

--- a/ils_middleware/tasks/sinopia/metadata_check.py
+++ b/ils_middleware/tasks/sinopia/metadata_check.py
@@ -1,4 +1,5 @@
 """Retrieves related AdminMetadata resource info for downstream tasks."""
+import ast
 import datetime
 import json
 import logging
@@ -77,8 +78,8 @@ def _retrieve_all_resource_refs(resources: list) -> dict:
             logging.error(msg)
             continue
 
-        metadata_uri = result.json().get("bfAdminMetadataAllRefs")
-        ils_info = _retrieve_all_metadata(metadata_uri)
+        metadata_uris = result.json().get("bfAdminMetadataAllRefs")
+        ils_info = _retrieve_all_metadata(metadata_uris)
         if ils_info:
             retrieved_resources[resource_uri] = ils_info
 
@@ -88,8 +89,8 @@ def _retrieve_all_resource_refs(resources: list) -> dict:
 def existing_metadata_check(*args, **kwargs):
     """Queries Sinopia API for related resources of an instance."""
     task_instance = kwargs["task_instance"]
-    resource_uris = task_instance.xcom_pull(
-        key="resources", task_ids=["sqs-message-parse"]
+    resource_uris = ast.literal_eval(
+        task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])
     )
     resource_refs = _retrieve_all_resource_refs(resource_uris)
     new_resources = []

--- a/ils_middleware/tasks/sinopia/metadata_check.py
+++ b/ils_middleware/tasks/sinopia/metadata_check.py
@@ -100,7 +100,7 @@ def existing_metadata_check(*args, **kwargs) -> Optional[str]:
 
             overlay_data[key] = value
         
-        overlay_resources.append({f"{resource_uri}": overlay_data})
+        overlay_resources.append({"resource_uri": resource_uri, "data": overlay_data})
 
     task_instance.xcom_push(key="new_resources", value=new_resources)
     task_instance.xcom_push(key="overlay_resources", value=overlay_resources)

--- a/ils_middleware/tasks/sinopia/metadata_check.py
+++ b/ils_middleware/tasks/sinopia/metadata_check.py
@@ -1,5 +1,4 @@
 """Retrieves related AdminMetadata resource info for downstream tasks."""
-import ast
 import datetime
 import json
 import logging
@@ -89,9 +88,10 @@ def _retrieve_all_resource_refs(resources: list) -> dict:
 def existing_metadata_check(*args, **kwargs):
     """Queries Sinopia API for related resources of an instance."""
     task_instance = kwargs["task_instance"]
-    resource_uris = ast.literal_eval(
-        task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])
+    resource_uris = task_instance.xcom_pull(
+        key="resources", task_ids="sqs-message-parse"
     )
+
     resource_refs = _retrieve_all_resource_refs(resource_uris)
     new_resources = []
     overlay_resources = []

--- a/ils_middleware/tasks/sinopia/metadata_check.py
+++ b/ils_middleware/tasks/sinopia/metadata_check.py
@@ -92,14 +92,14 @@ def existing_metadata_check(*args, **kwargs) -> Optional[str]:
         # Sort retrieved ILS by date
         ils_info = sorted(ils_info, key=lambda x: x["export_date"], reverse=True)
 
-        # Add only the latest ILS information to XCOM        
+        # Add only the latest ILS information to XCOM
         overlay_data = {}
         for key, value in ils_info[0].items():
             if key.startswith("export_date"):
                 continue
 
             overlay_data[key] = value
-        
+
         overlay_resources.append({"resource_uri": resource_uri, "data": overlay_data})
 
     task_instance.xcom_push(key="new_resources", value=new_resources)

--- a/ils_middleware/tasks/sinopia/metadata_check.py
+++ b/ils_middleware/tasks/sinopia/metadata_check.py
@@ -42,7 +42,7 @@ def _get_retrieve_metadata_resource(uri: str) -> Optional[dict]:
     if metadata_result.status_code > 399:
         msg = f"{uri} retrieval failed {metadata_result.status_code}\n{metadata_result.text}"
         logging.error(msg)
-        raise Exception(msg)
+        return None
 
     resource = metadata_result.json()
 
@@ -52,55 +52,55 @@ def _get_retrieve_metadata_resource(uri: str) -> Optional[dict]:
     return _query_for_ils_info(json.dumps(resource.get("data")), uri)
 
 
-def _check_return_refs(resource_refs_uri: str) -> list:
-    resource_ref_results = requests.get(resource_refs_uri)
-    if resource_ref_results.status_code > 399:
-        msg = f"{resource_refs_uri} retrieval failed {resource_ref_results.status_code}\n{resource_ref_results.text}"
-        logging.error(msg)
-        raise Exception(msg)
-    return resource_ref_results.json().get("bfAdminMetadataAllRefs", [])
-
-
-def _retrieve_all_metadata(bf_admin_metadata_all: list) -> list:
+def _retrieve_all_metadata(bf_admin_metadata_all: list) -> Optional[list]:
     ils_info = []
     for metadata_uri in bf_admin_metadata_all:
         metadata = _get_retrieve_metadata_resource(metadata_uri)
         if metadata:
+            metadata.pop(
+                "export_date", None
+            )  # we do not want to overlay this value, so remove
             ils_info.append(metadata)
-    return ils_info
+
+    if len(ils_info) > 0:
+        return ils_info
+
+    return None
 
 
-def existing_metadata_check(*args, **kwargs) -> Optional[str]:
+def _retrieve_all_resource_refs(resources: list) -> dict:
+    retrieved_resources = {}
+    for resource_uri in resources:
+        result = requests.get(f"{resource_uri}/relationships")
+        if result.status_code > 399:
+            msg = f"Failed to retrieve {resource_uri}: {result.status_code}\n{result.text}"
+            logging.error(msg)
+            continue
+
+        metadata_uri = result.json().get("bfAdminMetadataAllRefs")
+        ils_info = _retrieve_all_metadata(metadata_uri)
+        if ils_info:
+            retrieved_resources[resource_uri] = ils_info
+
+    return retrieved_resources
+
+
+def existing_metadata_check(*args, **kwargs):
     """Queries Sinopia API for related resources of an instance."""
     task_instance = kwargs["task_instance"]
-    resources = task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])
+    resource_uris = task_instance.xcom_pull(
+        key="resources", task_ids=["sqs-message-parse"]
+    )
+    resource_refs = _retrieve_all_resource_refs(resource_uris)
     new_resources = []
     overlay_resources = []
-    for resource_uri in resources:
-        bf_admin_metadata_all = _check_return_refs(f"{resource_uri}/relationships")
-
-        if len(bf_admin_metadata_all) < 1:
+    for resource_uri in resource_uris:
+        if resource_uri in resource_refs:
+            overlay_resources.append(
+                {"resource_uri": resource_uri, "data": resource_refs[resource_uri]}
+            )
+        else:
             new_resources.append(resource_uri)
-            continue
-
-        ils_info = _retrieve_all_metadata(bf_admin_metadata_all)
-
-        if len(ils_info) < 1:
-            new_resources.append(resource_uri)
-            continue
-
-        # Sort retrieved ILS by date
-        ils_info = sorted(ils_info, key=lambda x: x["export_date"], reverse=True)
-
-        # Add only the latest ILS information to XCOM
-        overlay_data = {}
-        for key, value in ils_info[0].items():
-            if key.startswith("export_date"):
-                continue
-
-            overlay_data[key] = value
-
-        overlay_resources.append({"resource_uri": resource_uri, "data": overlay_data})
 
     task_instance.xcom_push(key="new_resources", value=new_resources)
     task_instance.xcom_push(key="overlay_resources", value=overlay_resources)

--- a/ils_middleware/tasks/sinopia/rdf2marc.py
+++ b/ils_middleware/tasks/sinopia/rdf2marc.py
@@ -10,52 +10,51 @@ logger = logging.getLogger(__name__)
 
 def Rdf2Marc(**kwargs):
     """Runs rdf2marc on a BF Instance URL"""
-    instance_uri = kwargs.get("instance_uri")
+    task_instance = kwargs.get("task_instance")
+    resources = task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])
 
-    instance_path = urlparse(instance_uri).path
-    instance_id = path.split(instance_path)[-1]
+    results = {"complete": [], "errors": []}
 
-    rdf2marc_lambda = kwargs.get("rdf2marc_lambda")
+    for resource in resources:
+        instance_uri = resource["resource_uri"]
+        instance_path = urlparse(instance_uri).path
+        instance_id = path.split(instance_path)[-1]
 
-    s3_bucket = kwargs.get("s3_bucket")
-    s3_record_path = f"airflow/{instance_id}/record"
-    marc_path = f"{s3_record_path}.mar"
-    marc_text_path = f"{s3_record_path}.txt"
-    marc_err_path = f"{s3_record_path}.err"
+        rdf2marc_lambda = kwargs.get("rdf2marc_lambda")
 
-    lambda_hook = AwsLambdaHook(
-        rdf2marc_lambda,
-        log_type="None",
-        qualifier="$LATEST",
-        invocation_type="RequestResponse",
-        config=None,
-        aws_conn_id="aws_lambda_connection",
-    )
+        s3_bucket = kwargs.get("s3_bucket")
+        s3_record_path = f"airflow/{instance_id}/record"
+        marc_path = f"{s3_record_path}.mar"
+        marc_text_path = f"{s3_record_path}.txt"
+        marc_err_path = f"{s3_record_path}.err"
 
-    params = {
-        "instance_uri": instance_uri,
-        "bucket": s3_bucket,
-        "marc_path": marc_path,
-        "marc_txt_path": marc_text_path,
-        "error_path": marc_err_path,
-    }
+        lambda_hook = AwsLambdaHook(
+            rdf2marc_lambda,
+            log_type="None",
+            qualifier="$LATEST",
+            invocation_type="RequestResponse",
+            config=None,
+            aws_conn_id="aws_lambda_connection",
+        )
 
-    result = lambda_hook.invoke_lambda(payload=json.dumps(params))
+        params = {
+            "instance_uri": instance_uri,
+            "bucket": s3_bucket,
+            "marc_path": marc_path,
+            "marc_txt_path": marc_text_path,
+            "error_path": marc_err_path,
+        }
 
-    logger.debug(f"RESULT = {result['StatusCode']}")
+        result = lambda_hook.invoke_lambda(payload=json.dumps(params))
 
-    payload = json.loads(result["Payload"].read())
+        if "x-amz-function-error" in result["ResponseMetadata"].get("HTTPHeaders"):
+            payload = json.loads(result["Payload"].read())
+            msg = f"RDF2MARC conversion failed for {instance_uri}, error: {payload.get('errorMessage')}"
+            results["errors"].append({"instance_uri": instance_uri, "message": msg})
+        elif result["StatusCode"] == 200:
+            results["complete"].append(instance_uri)
+        else:
+            msg = f"RDF2MARC conversion failed for {instance_uri}: {result['FunctionError']}"
+            results["errors"].append({"instance_uri": instance_uri, "message": msg})
 
-    if "x-amz-function-error" in result["ResponseMetadata"].get("HTTPHeaders"):
-        msg = f"RDF2MARC conversion failed for {instance_uri}, error: {payload.get('errorMessage')}"
-        logger.error(msg)
-
-        raise Exception(msg)
-
-    if result["StatusCode"] == 200:
-        return instance_id
-
-    logger.error(
-        f"RDF2MARC conversion failed for {instance_uri}: {result['FunctionError']}"
-    )
-    raise Exception()
+    return results

--- a/ils_middleware/tasks/sinopia/rdf2marc.py
+++ b/ils_middleware/tasks/sinopia/rdf2marc.py
@@ -1,3 +1,4 @@
+import ast
 import logging
 import json
 from urllib.parse import urlparse
@@ -11,7 +12,9 @@ logger = logging.getLogger(__name__)
 def Rdf2Marc(**kwargs):
     """Runs rdf2marc on a BF Instance URL"""
     task_instance = kwargs.get("task_instance")
-    resources = task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])
+    resources = ast.literal_eval(
+        task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])
+    )
 
     for instance_uri in resources:
         instance_path = urlparse(instance_uri).path

--- a/ils_middleware/tasks/sinopia/rdf2marc.py
+++ b/ils_middleware/tasks/sinopia/rdf2marc.py
@@ -1,4 +1,3 @@
-import ast
 import logging
 import json
 from urllib.parse import urlparse
@@ -12,9 +11,7 @@ logger = logging.getLogger(__name__)
 def Rdf2Marc(**kwargs):
     """Runs rdf2marc on a BF Instance URL"""
     task_instance = kwargs.get("task_instance")
-    resources = ast.literal_eval(
-        task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])
-    )
+    resources = task_instance.xcom_pull(key="resources", task_ids="sqs-message-parse")
 
     for instance_uri in resources:
         instance_path = urlparse(instance_uri).path

--- a/ils_middleware/tasks/sinopia/update_resource.py
+++ b/ils_middleware/tasks/sinopia/update_resource.py
@@ -31,9 +31,9 @@ def update_resource_new_metadata(*args, **kwargs) -> str:
     update_failed = []
     resource_not_found = []
 
-    for resource in resources:
-        resource_uri = resource.get("resource_uri")
-        metadata_uri = resource.get("metadata_uri")
+    for resource_uri in resources:
+        # resource_uri = resource.get("resource_uri")
+        metadata_uri = task_instance.xcom_pull(key=resource_uri, task_ids=["sinopia-new-metadata"])  # resource.get("metadata_uri")
 
         result = requests.get(resource_uri)
 

--- a/ils_middleware/tasks/sinopia/update_resource.py
+++ b/ils_middleware/tasks/sinopia/update_resource.py
@@ -1,5 +1,4 @@
 """Updates Resource with new local Admin Metadata"""
-import ast
 import json
 import logging
 
@@ -26,9 +25,7 @@ def update_resource_new_metadata(*args, **kwargs):
     """Updates Resource RDF with new local AdminMetadata URI"""
     jwt = kwargs.get("jwt")
     task_instance = kwargs["task_instance"]
-    resources = ast.literal_eval(
-        task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])
-    )
+    resources = task_instance.xcom_pull(key="resources", task_ids="sqs-message-parse")
 
     updated_resources = []
     update_failed = []
@@ -36,7 +33,7 @@ def update_resource_new_metadata(*args, **kwargs):
 
     for resource_uri in resources:
         metadata_uri = task_instance.xcom_pull(
-            key=resource_uri, task_ids=["sinopia-new-metadata"]
+            key=resource_uri, task_ids="sinopia-new-metadata"
         )
 
         result = requests.get(resource_uri)

--- a/ils_middleware/tasks/sinopia/update_resource.py
+++ b/ils_middleware/tasks/sinopia/update_resource.py
@@ -33,7 +33,9 @@ def update_resource_new_metadata(*args, **kwargs) -> str:
 
     for resource_uri in resources:
         # resource_uri = resource.get("resource_uri")
-        metadata_uri = task_instance.xcom_pull(key=resource_uri, task_ids=["sinopia-new-metadata"])  # resource.get("metadata_uri")
+        metadata_uri = task_instance.xcom_pull(
+            key=resource_uri, task_ids=["sinopia-new-metadata"]
+        )
 
         result = requests.get(resource_uri)
 

--- a/ils_middleware/tasks/sinopia/update_resource.py
+++ b/ils_middleware/tasks/sinopia/update_resource.py
@@ -21,7 +21,7 @@ def _get_update_rdf(resource_uri, metadata_uri, raw_json_ld: str) -> str:
     return graph.serialize(format="json-ld")
 
 
-def update_resource_new_metadata(*args, **kwargs) -> str:
+def update_resource_new_metadata(*args, **kwargs):
     """Updates Resource RDF with new local AdminMetadata URI"""
     jwt = kwargs.get("jwt")
     task_instance = kwargs["task_instance"]

--- a/ils_middleware/tasks/sinopia/update_resource.py
+++ b/ils_middleware/tasks/sinopia/update_resource.py
@@ -11,7 +11,6 @@ BF = rdflib.Namespace("http://id.loc.gov/ontologies/bibframe/")
 
 
 def _get_update_rdf(resource_uri, metadata_uri, raw_json_ld: str) -> str:
-
     resource_uri_node = rdflib.URIRef(resource_uri)
     metadata_uri_node = rdflib.URIRef(metadata_uri)
 
@@ -25,31 +24,45 @@ def _get_update_rdf(resource_uri, metadata_uri, raw_json_ld: str) -> str:
 def update_resource_new_metadata(*args, **kwargs) -> str:
     """Updates Resource RDF with new local AdminMetadata URI"""
     jwt = kwargs.get("jwt")
-    resource_uri = kwargs.get("resource_uri")
-    metadata_uri = kwargs.get("metadata_uri")
+    task_instance = kwargs["task_instance"]
+    resources = task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])
 
-    result = requests.get(resource_uri)
+    updated_resources = []
+    update_failed = []
+    resource_not_found = []
 
-    if result.status_code > 399:
-        msg = f"{resource_uri} retrieval error {result.status_code}\n{result.text}"
-        logger.error(msg)
-        raise Exception(msg)
+    for resource in resources:
+        resource_uri = resource.get("resource_uri")
+        metadata_uri = resource.get("metadata_uri")
 
-    sinopia_doc = result.json()
-    updated_json_ld = _get_update_rdf(
-        resource_uri, metadata_uri, json.dumps(sinopia_doc.get("data"))
-    )
+        result = requests.get(resource_uri)
 
-    headers = {"Authorization": f"Bearer {jwt}", "Content-Type": "application/json"}
+        if result.status_code > 399:
+            msg = f"{resource_uri} retrieval error {result.status_code}\n{result.text}"
+            logger.error(msg)
+            resource_not_found.append(resource_uri)
+            continue
 
-    sinopia_doc["data"] = json.loads(updated_json_ld)
-    sinopia_doc["bfAdminMetadataRefs"].append(metadata_uri)
+        sinopia_doc = result.json()
+        updated_json_ld = _get_update_rdf(
+            resource_uri, metadata_uri, json.dumps(sinopia_doc.get("data"))
+        )
 
-    update_result = requests.put(resource_uri, json=sinopia_doc, headers=headers)
+        headers = {"Authorization": f"Bearer {jwt}", "Content-Type": "application/json"}
 
-    if update_result.status_code > 399:
-        msg = f"Failed to update {resource_uri}, status code {update_result.status_code}\n{update_result.text}"
-        logger.error(msg)
-        raise Exception(msg)
+        sinopia_doc["data"] = json.loads(updated_json_ld)
+        sinopia_doc["bfAdminMetadataRefs"].append(metadata_uri)
 
-    return "resource_updated"
+        update_result = requests.put(resource_uri, json=sinopia_doc, headers=headers)
+
+        if update_result.status_code > 399:
+            msg = f"Failed to update {resource_uri}, status code {update_result.status_code}\n{update_result.text}"
+            logger.error(msg)
+            update_failed.append(resource_uri)
+            continue
+
+        updated_resources.append(resource_uri)
+
+    task_instance.xcom_push(key="updated_resources", value=updated_resources)
+    task_instance.xcom_push(key="update_failed", value=update_failed)
+    task_instance.xcom_push(key="resource_not_found", value=resource_not_found)

--- a/ils_middleware/tasks/sinopia/update_resource.py
+++ b/ils_middleware/tasks/sinopia/update_resource.py
@@ -1,4 +1,5 @@
 """Updates Resource with new local Admin Metadata"""
+import ast
 import json
 import logging
 
@@ -25,14 +26,15 @@ def update_resource_new_metadata(*args, **kwargs):
     """Updates Resource RDF with new local AdminMetadata URI"""
     jwt = kwargs.get("jwt")
     task_instance = kwargs["task_instance"]
-    resources = task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])
+    resources = ast.literal_eval(
+        task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])
+    )
 
     updated_resources = []
     update_failed = []
     resource_not_found = []
 
     for resource_uri in resources:
-        # resource_uri = resource.get("resource_uri")
         metadata_uri = task_instance.xcom_pull(
             key=resource_uri, task_ids=["sinopia-new-metadata"]
         )

--- a/ils_middleware/tasks/symphony/mod_json.py
+++ b/ils_middleware/tasks/symphony/mod_json.py
@@ -38,11 +38,13 @@ def to_symphony_json(**kwargs):
     task_instance = kwargs.get("task_instance")
     resources = task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])
     for instance_uri in resources:
-        marc_raw_json = task_instance.xcom_pull(key=instance_uri, task_ids=["process_symphony.marc_json_to_s3"])
+        marc_raw_json = task_instance.xcom_pull(
+            key=instance_uri, task_ids=["process_symphony.marc_json_to_s3"]
+        )
         pymarc_json = json.loads(marc_raw_json)
         record = {"standard": "MARC21", "type": "BIB", "fields": []}
         record["leader"] = pymarc_json.get("leader")
         for field in pymarc_json["fields"]:
             record["fields"].append(_get_fields(field))
-        
+
         task_instance.xcom_push(key=instance_uri, value=record)

--- a/ils_middleware/tasks/symphony/mod_json.py
+++ b/ils_middleware/tasks/symphony/mod_json.py
@@ -1,5 +1,4 @@
 """Converts PYMARC JSON to Symphony JSON"""
-import ast
 import json
 import logging
 
@@ -37,12 +36,11 @@ def _get_fields(field):
 def to_symphony_json(**kwargs):
     """Converst pymarc MARC json to Symphony JSON varient."""
     task_instance = kwargs.get("task_instance")
-    resources = ast.literal_eval(
-        task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])
-    )
+    resources = task_instance.xcom_pull(key="resources", task_ids="sqs-message-parse")
+
     for instance_uri in resources:
         marc_raw_json = task_instance.xcom_pull(
-            key=instance_uri, task_ids=["process_symphony.marc_json_to_s3"]
+            key=instance_uri, task_ids="process_symphony.marc_json_to_s3"
         )
         pymarc_json = json.loads(marc_raw_json)
         record = {"standard": "MARC21", "type": "BIB", "fields": []}

--- a/ils_middleware/tasks/symphony/mod_json.py
+++ b/ils_middleware/tasks/symphony/mod_json.py
@@ -1,4 +1,5 @@
 """Converts PYMARC JSON to Symphony JSON"""
+import ast
 import json
 import logging
 
@@ -36,7 +37,9 @@ def _get_fields(field):
 def to_symphony_json(**kwargs):
     """Converst pymarc MARC json to Symphony JSON varient."""
     task_instance = kwargs.get("task_instance")
-    resources = task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])
+    resources = ast.literal_eval(
+        task_instance.xcom_pull(key="resources", task_ids=["sqs-message-parse"])
+    )
     for instance_uri in resources:
         marc_raw_json = task_instance.xcom_pull(
             key=instance_uri, task_ids=["process_symphony.marc_json_to_s3"]

--- a/ils_middleware/tasks/symphony/new.py
+++ b/ils_middleware/tasks/symphony/new.py
@@ -5,7 +5,7 @@ import json
 from ils_middleware.tasks.symphony.request import SymphonyRequest
 
 
-def NewMARCtoSymphony(**kwargs) -> str:
+def NewMARCtoSymphony(**kwargs):
     """Creates a new record in Symphony and returns the new CatKey"""
     library_key = kwargs.get("library_key")
     item_type = kwargs.get("item_type")

--- a/ils_middleware/tasks/symphony/new.py
+++ b/ils_middleware/tasks/symphony/new.py
@@ -7,45 +7,52 @@ from ils_middleware.tasks.symphony.request import SymphonyRequest
 
 def NewMARCtoSymphony(**kwargs) -> str:
     """Creates a new record in Symphony and returns the new CatKey"""
-    marc_json = kwargs.get("marc_json", "")
     library_key = kwargs.get("library_key")
     item_type = kwargs.get("item_type")
     home_location = kwargs.get("home_location")
+    task_instance = kwargs.get("task_instance")
+    resources = task_instance.xcom_pull(key="new_resources", task_ids=["process_symphony.new-or-overlay"])
 
-    marc_json = ast.literal_eval(marc_json)
+    for resource_uri in resources:
+        marc_json = task_instance.xcom_pull(key=resource_uri, task_ids=["process_symphony.convert_to_symphony_json"])
+        
+        marc_json = ast.literal_eval(marc_json)
 
-    payload = {
-        "@resource": "/catalog/bib",
-        "catalogFormat": {"@resource": "/policy/catalogFormat", "@key": "MARC"},
-        "shadowed": False,
-        "bib": marc_json,
-        "callList": [
-            {
-                "@resource": "/catalog/call",
-                "callNumber": "AUTO",
-                "classification": {"@resource": "/policy/classification", "@key": "LC"},
-                "library": {"@resource": "/policy/library", "@key": f"{library_key}"},
-                "itemList": [
-                    {
-                        "@resource": "/catalog/item",
-                        "barcode": "AUTO",
-                        "itemType": {
-                            "@resource": "/policy/itemType",
-                            "@key": f"{item_type}",
-                        },
-                        "homeLocation": {
-                            "@resource": "/policy/location",
-                            "@key": f"{home_location}",
-                        },
-                    }
-                ],
-            }
-        ],
-    }
+        payload = {
+            "@resource": "/catalog/bib",
+            "catalogFormat": {"@resource": "/policy/catalogFormat", "@key": "MARC"},
+            "shadowed": False,
+            "bib": marc_json,
+            "callList": [
+                {
+                    "@resource": "/catalog/call",
+                    "callNumber": "AUTO",
+                    "classification": {"@resource": "/policy/classification", "@key": "LC"},
+                    "library": {"@resource": "/policy/library", "@key": f"{library_key}"},
+                    "itemList": [
+                        {
+                            "@resource": "/catalog/item",
+                            "barcode": "AUTO",
+                            "itemType": {
+                                "@resource": "/policy/itemType",
+                                "@key": f"{item_type}",
+                            },
+                            "homeLocation": {
+                                "@resource": "/policy/location",
+                                "@key": f"{home_location}",
+                            },
+                        }
+                    ],
+                }
+            ],
+        }
 
-    return SymphonyRequest(
-        **kwargs,
-        data=json.dumps(payload),
-        endpoint="catalog/bib",
-        filter=lambda response: response.json().get("@key"),
-    )
+        task_instance.xcom_push(
+            key=resource_uri,
+            value=SymphonyRequest(
+                **kwargs,
+                data=json.dumps(payload),
+                endpoint="catalog/bib",
+                filter=lambda response: response.json().get("@key"),
+            )
+        )

--- a/ils_middleware/tasks/symphony/new.py
+++ b/ils_middleware/tasks/symphony/new.py
@@ -11,11 +11,15 @@ def NewMARCtoSymphony(**kwargs) -> str:
     item_type = kwargs.get("item_type")
     home_location = kwargs.get("home_location")
     task_instance = kwargs.get("task_instance")
-    resources = task_instance.xcom_pull(key="new_resources", task_ids=["process_symphony.new-or-overlay"])
+    resources = task_instance.xcom_pull(
+        key="new_resources", task_ids=["process_symphony.new-or-overlay"]
+    )
 
     for resource_uri in resources:
-        marc_json = task_instance.xcom_pull(key=resource_uri, task_ids=["process_symphony.convert_to_symphony_json"])
-        
+        marc_json = task_instance.xcom_pull(
+            key=resource_uri, task_ids=["process_symphony.convert_to_symphony_json"]
+        )
+
         marc_json = ast.literal_eval(marc_json)
 
         payload = {
@@ -27,8 +31,14 @@ def NewMARCtoSymphony(**kwargs) -> str:
                 {
                     "@resource": "/catalog/call",
                     "callNumber": "AUTO",
-                    "classification": {"@resource": "/policy/classification", "@key": "LC"},
-                    "library": {"@resource": "/policy/library", "@key": f"{library_key}"},
+                    "classification": {
+                        "@resource": "/policy/classification",
+                        "@key": "LC",
+                    },
+                    "library": {
+                        "@resource": "/policy/library",
+                        "@key": f"{library_key}",
+                    },
                     "itemList": [
                         {
                             "@resource": "/catalog/item",
@@ -54,5 +64,5 @@ def NewMARCtoSymphony(**kwargs) -> str:
                 data=json.dumps(payload),
                 endpoint="catalog/bib",
                 filter=lambda response: response.json().get("@key"),
-            )
+            ),
         )

--- a/ils_middleware/tasks/symphony/new.py
+++ b/ils_middleware/tasks/symphony/new.py
@@ -13,13 +13,13 @@ def NewMARCtoSymphony(**kwargs):
     task_instance = kwargs.get("task_instance")
     resources = ast.literal_eval(
         task_instance.xcom_pull(
-            key="new_resources", task_ids=["process_symphony.new-or-overlay"]
+            key="new_resources", task_ids="process_symphony.new-or-overlay"
         )
     )
 
     for resource_uri in resources:
         marc_json = task_instance.xcom_pull(
-            key=resource_uri, task_ids=["process_symphony.convert_to_symphony_json"]
+            key=resource_uri, task_ids="process_symphony.convert_to_symphony_json"
         )
 
         marc_json = ast.literal_eval(marc_json)

--- a/ils_middleware/tasks/symphony/new.py
+++ b/ils_middleware/tasks/symphony/new.py
@@ -11,8 +11,10 @@ def NewMARCtoSymphony(**kwargs):
     item_type = kwargs.get("item_type")
     home_location = kwargs.get("home_location")
     task_instance = kwargs.get("task_instance")
-    resources = task_instance.xcom_pull(
-        key="new_resources", task_ids=["process_symphony.new-or-overlay"]
+    resources = ast.literal_eval(
+        task_instance.xcom_pull(
+            key="new_resources", task_ids=["process_symphony.new-or-overlay"]
+        )
     )
 
     for resource_uri in resources:

--- a/ils_middleware/tasks/symphony/overlay.py
+++ b/ils_middleware/tasks/symphony/overlay.py
@@ -12,27 +12,39 @@ logger = logging.getLogger(__name__)
 
 def overlay_marc_in_symphony(*args, **kwargs) -> str:
     """Overlays an existing record in Symphony"""
-    marc_json = kwargs.get("marc_json", "")
-    catkey = kwargs.get("catkey")
+    task_instance = kwargs.get("task_instance")
+    resources = task_instance.xcom_pull(key="overlay_resources", task_ids=["process_symphony.new-or-overlay"])
 
-    if not catkey:
-        msg = "Catalog ID is required"
-        logger.error(msg)
-        raise ValueError(msg)
+    missing_catkeys = []
 
-    marc_json = ast.literal_eval(marc_json)
+    for resource in resources:
+        resource_uri = resource["resource_uri"]
+        catkey = resource["data"].get("catkey")
+        marc_json = task_instance.xcom_pull(key=resource_uri, task_ids=["process_symphony.convert_to_symphony_json"])
 
-    payload = {
-        "@resource": "/catalog/bib",
-        "@key": catkey,
-        "catalogDate": datetime.datetime.now().strftime("%Y-%m-%d"),
-        "bib": marc_json,
-    }
+        if not catkey:
+            msg = f"Catalog ID is required for {resource_uri}"
+            missing_catkeys.append(resource_uri)
+            logger.error(msg)
 
-    return SymphonyRequest(
-        **kwargs,
-        data=json.dumps(payload),
-        http_verb="put",
-        endpoint=f"catalog/bib/key/{catkey}",
-        filter=lambda response: response.json().get("@key"),
-    )
+        marc_json = ast.literal_eval(marc_json)
+
+        payload = {
+            "@resource": "/catalog/bib",
+            "@key": catkey,
+            "catalogDate": datetime.datetime.now().strftime("%Y-%m-%d"),
+            "bib": marc_json,
+        }
+
+        task_instance.xcom_push(
+            key=resource_uri,
+            value=SymphonyRequest(
+                **kwargs,
+                data=json.dumps(payload),
+                http_verb="put",
+                endpoint=f"catalog/bib/key/{catkey}",
+                filter=lambda response: response.json().get("@key"),
+            )
+        )
+    
+    task_instance.xcom_push(key="missing_catkeys", value=missing_catkeys)

--- a/ils_middleware/tasks/symphony/overlay.py
+++ b/ils_middleware/tasks/symphony/overlay.py
@@ -13,25 +13,26 @@ logger = logging.getLogger(__name__)
 def overlay_marc_in_symphony(*args, **kwargs):
     """Overlays an existing record in Symphony"""
     task_instance = kwargs.get("task_instance")
-    resources = task_instance.xcom_pull(
-        key="overlay_resources", task_ids=["process_symphony.new-or-overlay"]
+    resources = ast.literal_eval(
+        task_instance.xcom_pull(
+            key="overlay_resources", task_ids=["process_symphony.new-or-overlay"]
+        )
     )
 
     missing_catkeys = []
-
     for resource in resources:
         resource_uri = resource["resource_uri"]
         catkey = resource["data"].get("catkey")
-        marc_json = task_instance.xcom_pull(
-            key=resource_uri, task_ids=["process_symphony.convert_to_symphony_json"]
+        marc_json = ast.literal_eval(
+            task_instance.xcom_pull(
+                key=resource_uri, task_ids=["process_symphony.convert_to_symphony_json"]
+            )
         )
 
         if not catkey:
             msg = f"Catalog ID is required for {resource_uri}"
             missing_catkeys.append(resource_uri)
             logger.error(msg)
-
-        marc_json = ast.literal_eval(marc_json)
 
         payload = {
             "@resource": "/catalog/bib",

--- a/ils_middleware/tasks/symphony/overlay.py
+++ b/ils_middleware/tasks/symphony/overlay.py
@@ -1,6 +1,5 @@
 """Overlays an existing Symphony record"""
 
-import ast
 import datetime
 import json
 import logging
@@ -13,20 +12,16 @@ logger = logging.getLogger(__name__)
 def overlay_marc_in_symphony(*args, **kwargs):
     """Overlays an existing record in Symphony"""
     task_instance = kwargs.get("task_instance")
-    resources = ast.literal_eval(
-        task_instance.xcom_pull(
-            key="overlay_resources", task_ids=["process_symphony.new-or-overlay"]
-        )
+    resources = task_instance.xcom_pull(
+        key="overlay_resources", task_ids="process_symphony.new-or-overlay"
     )
 
     missing_catkeys = []
     for resource in resources:
         resource_uri = resource["resource_uri"]
         catkey = resource["data"].get("catkey")
-        marc_json = ast.literal_eval(
-            task_instance.xcom_pull(
-                key=resource_uri, task_ids=["process_symphony.convert_to_symphony_json"]
-            )
+        marc_json = task_instance.xcom_pull(
+            key=resource_uri, task_ids="process_symphony.convert_to_symphony_json"
         )
 
         if not catkey:

--- a/ils_middleware/tasks/symphony/overlay.py
+++ b/ils_middleware/tasks/symphony/overlay.py
@@ -10,7 +10,7 @@ from ils_middleware.tasks.symphony.request import SymphonyRequest
 logger = logging.getLogger(__name__)
 
 
-def overlay_marc_in_symphony(*args, **kwargs) -> str:
+def overlay_marc_in_symphony(*args, **kwargs):
     """Overlays an existing record in Symphony"""
     task_instance = kwargs.get("task_instance")
     resources = task_instance.xcom_pull(

--- a/ils_middleware/tasks/symphony/overlay.py
+++ b/ils_middleware/tasks/symphony/overlay.py
@@ -13,14 +13,18 @@ logger = logging.getLogger(__name__)
 def overlay_marc_in_symphony(*args, **kwargs) -> str:
     """Overlays an existing record in Symphony"""
     task_instance = kwargs.get("task_instance")
-    resources = task_instance.xcom_pull(key="overlay_resources", task_ids=["process_symphony.new-or-overlay"])
+    resources = task_instance.xcom_pull(
+        key="overlay_resources", task_ids=["process_symphony.new-or-overlay"]
+    )
 
     missing_catkeys = []
 
     for resource in resources:
         resource_uri = resource["resource_uri"]
         catkey = resource["data"].get("catkey")
-        marc_json = task_instance.xcom_pull(key=resource_uri, task_ids=["process_symphony.convert_to_symphony_json"])
+        marc_json = task_instance.xcom_pull(
+            key=resource_uri, task_ids=["process_symphony.convert_to_symphony_json"]
+        )
 
         if not catkey:
             msg = f"Catalog ID is required for {resource_uri}"
@@ -44,7 +48,7 @@ def overlay_marc_in_symphony(*args, **kwargs) -> str:
                 http_verb="put",
                 endpoint=f"catalog/bib/key/{catkey}",
                 filter=lambda response: response.json().get("@key"),
-            )
+            ),
         )
-    
+
     task_instance.xcom_push(key="missing_catkeys", value=missing_catkeys)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,12 @@
 [flake8]
 max-line-length = 130
 extend-ignore = E203
+per-file-ignores =
+    # imported but unused
+    test_s3.py: F401, F811
 
 [tool:pytest]
 addopts = --cov=ils_middleware --cov-report=xml --cov-report=term
+
+[pytest]
+norecursedirs=tests/helpers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+import os
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "helpers"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,0 @@
-import sys
-import os
-
-sys.path.append(os.path.join(os.path.dirname(__file__), "helpers"))

--- a/tests/fixtures/record.json
+++ b/tests/fixtures/record.json
@@ -1,0 +1,26 @@
+{
+  "leader": "01455nam a2200277uu 4500",
+  "fields": [
+      {"003": "cst"},
+      {"008": "200915|||||||||enk                 eng||"},
+      {"010": {"subfields": [{"a": "981811"}], "ind1": " ", "ind2": " "}},
+      {"020": {"subfields": [{"a": "0892816619"}, {"q": "(hardcover)"}], "ind1": " ", "ind2": " "}},
+      {"040": {"subfields": [{"a": "cst"}, {"b": "eng"}, {"c": "cst"}, {"e": "rda"}], "ind1": " ", "ind2": " "}},
+      {"050": {"subfields": [{"a": "R128.H5313"}, {"b": "1998"}], "ind1": " ", "ind2": "0"}},
+      {"100": {"subfields": [{"a": "Hildegard"}, {"c": "Saint,"}, {"d": "1098-1179"}, {"0": "http://id.loc.gov/authorities/names/n80118409"}], "ind1": "0", "ind2": " "}},
+      {"245": {"subfields": [{"a": "Hildegard von Bingen's Physica"}, {"b": "the complete English translation of her classic work on health and healing"}, {"c": "translated from the Latin by Priscilla Throop ; illustrations by Mary Elder Jacobsen"}], "ind1": "1", "ind2": "0"}},
+      {"246": {"subfields": [{"a": "Physica"}], "ind1": "0", "ind2": " "}},
+      {"264": {"subfields": [{"a": "Rochester (Vt.)"}, {"a": "London (England)"}, {"b": "Macmillan London"}], "ind1": " ", "ind2": "1"}},
+      {"300": {"subfields": [{"a": "250 pages"}], "ind1": " ", "ind2": " "}},
+      {"300": {"subfields": [{"c": "24 cm"}], "ind1": " ", "ind2": " "}},
+      {"336": {"subfields": [{"c": "txt"}, {"0": "http://id.loc.gov/vocabulary/contentTypes/txt"}, {"2": "rdacontent"}], "ind1": " ", "ind2": " "}},
+      {"337": {"subfields": [{"a": "unmediated"}, {"c": "n"}, {"0": "http://id.loc.gov/vocabulary/mediaTypes/n"}, {"2": "rdamedia"}], "ind1": " ", "ind2": " "}},
+      {"338": {"subfields": [{"a": "volume"}, {"c": "nc"}, {"0": "http://id.loc.gov/vocabulary/carriers/nc"}, {"2": "rdacarrier"}], "ind1": " ", "ind2": " "}}, 
+      {"500": {"subfields": [{"a": "Includes index"}], "ind1": " ", "ind2": " "}},
+      {"650": {"subfields": [{"a": "Medicine, Medieval"}, {"0": "http://id.loc.gov/authorities/subjects/sh85083152"}], "ind1": " ", "ind2": "0"}},
+      {"655": {"subfields": [{"a": "Handbooks and manuals"}, {"0": "http://id.loc.gov/authorities/genreForms/gf2014026109"}, {"2": "lcgft"}], "ind1": " ", "ind2": "0"}},
+      {"700": {"subfields": [{"a": "Throop, Priscilla"}, {"d": "1946-"}, {"0": "http://id.loc.gov/authorities/names/n98031191"}], "ind1": "1", "ind2": " "}},
+      {"700": {"subfields": [{"a": "Jacobsen, Mary Elder"}, {"0": "http://id.loc.gov/authorities/names/no2012148249"}], "ind1": "1", "ind2": " "}},
+      {"884": {"subfields": [{"a": "Sinopia rdf2marc"}, {"g": "20210921"}, {"k": "https://api.stage.sinopia.io/resource/3eb5f480-60d6-4732-8daf-02d8d6f26eb7"}, {"u": "https://github.com/LD4P/rdf2marc"}], "ind1": " ", "ind2": " "}}
+  ]
+}

--- a/tests/helpers/tasks.py
+++ b/tests/helpers/tasks.py
@@ -76,7 +76,7 @@ overlay_resources = [
     },
 ]
 
-mock_push_store = {}
+mock_push_store: dict = {}
 
 
 def mock_message():

--- a/tests/helpers/tasks.py
+++ b/tests/helpers/tasks.py
@@ -21,18 +21,80 @@ def test_task_instance():
     return TaskInstance(test_task())
 
 
+mock_resources = {
+    "https://api.development.sinopia.io/resource/0000-1111-2222-3333": {
+        "user": "jpnelson",
+        "group": "stanford",
+        "editGroups": ["other", "pcc"],
+        "templateId": "ld4p:RT:bf2:Monograph:Instance:Un-nested",
+        "types": ["http://id.loc.gov/ontologies/bibframe/Instance"],
+        "bfAdminMetadataRefs": [
+            "https://api.development.sinopia.io/resource/7f775ec2-4fe8-48a6-9cb4-5b218f9960f1",
+            "https://api.development.sinopia.io/resource/bc9e9939-45b3-4122-9b6d-d800c130c576",
+        ],
+        "bfItemRefs": [],
+        "bfInstanceRefs": [],
+        "bfWorkRefs": [
+            "https://api.development.sinopia.io/resource/6497a461-42dc-42bf-b433-5e47c73f7e89"
+        ],
+        "id": "7b55e6f7-f91e-4c7a-bbcd-c074485ad18d",
+        "uri": "https://api.development.sinopia.io/resource/7b55e6f7-f91e-4c7a-bbcd-c074485ad18d",
+        "timestamp": "2021-10-29T20:30:58.821Z",
+    },
+    "https://api.development.sinopia.io/resource/4444-5555-6666-7777": {
+        "user": "jpnelson",
+        "group": "stanford",
+        "editGroups": ["other", "pcc"],
+        "templateId": "ld4p:RT:bf2:Monograph:Instance:Un-nested",
+        "types": ["http://id.loc.gov/ontologies/bibframe/Instance"],
+        "bfAdminMetadataRefs": [
+            "https://api.development.sinopia.io/resource/7f775ec2-4fe8-48a6-9cb4-5b218f9960f1",
+            "https://api.development.sinopia.io/resource/bc9e9939-45b3-4122-9b6d-d800c130c576",
+        ],
+        "bfItemRefs": [],
+        "bfInstanceRefs": [],
+        "bfWorkRefs": [
+            "https://api.development.sinopia.io/resource/6497a461-42dc-42bf-b433-5e47c73f7e89"
+        ],
+        "id": "7b55e6f7-f91e-4c7a-bbcd-c074485ad18d",
+        "uri": "https://api.development.sinopia.io/resource/7b55e6f7-f91e-4c7a-bbcd-c074485ad18d",
+        "timestamp": "2021-10-29T20:30:58.821Z",
+    }
+}
+
 mock_push_store = {}
+
+def mock_message():
+    return [
+        [
+            {
+                "Body": """{ "user": { "email": "dscully@stanford.edu"},
+                            "resource": { "uri": "https://api.development.sinopia.io/resource/0000-1111-2222-3333" }}"""
+            }
+        ],
+        [
+            {
+                "Body": """{ "user": { "email": "fmulder@stanford.edu"},
+                            "resource": { "uri": "https://api.development.sinopia.io/resource/4444-5555-6666-7777" }}"""
+            }
+        ],
+    ]
 
 
 @pytest.fixture
 def mock_task_instance(monkeypatch):
     def mock_xcom_pull(*args, **kwargs):
         key = kwargs.get("key")
+        task_ids = kwargs.get("task_ids", [''])
         if key == "resources":
             return [
-                "http://example.com/rdf/0000-1111-2222-3333",
-                "http://example.com/rdf/4444-5555-6666-7777",
+                "https://api.development.sinopia.io/resource/0000-1111-2222-3333",
+                "https://api.development.sinopia.io/resource/4444-5555-6666-7777",
             ]
+        elif key == "messages":
+            return mock_message()
+        elif key in mock_resources and task_ids[0] == "sqs-message-parse":
+            return mock_resources[key]
         else:
             return mock_push_store[key]
 

--- a/tests/helpers/tasks.py
+++ b/tests/helpers/tasks.py
@@ -1,0 +1,52 @@
+import pytest
+import json
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators.dummy import DummyOperator
+from airflow.models.taskinstance import TaskInstance
+
+
+def test_task():
+    return DummyOperator(
+        task_id="test_task",
+        dag=DAG(
+            "test_dag",
+            default_args={"owner": "airflow", "start_date": datetime(2021, 9, 20)},
+        ),
+    )
+
+
+def test_task_instance():
+    return TaskInstance(test_task())
+
+
+mock_push_store = {}
+
+
+@pytest.fixture
+def mock_task_instance(monkeypatch):
+    def mock_xcom_pull(*args, **kwargs):
+        key = kwargs.get("key")
+        if key == "resources":
+            return [
+                "http://example.com/rdf/0000-1111-2222-3333",
+                "http://example.com/rdf/4444-5555-6666-7777",
+            ]
+        else:
+            return mock_push_store[key]
+
+    def mock_xcom_push(*args, **kwargs):
+        key = kwargs.get("key")
+        value = kwargs.get("value")
+        mock_push_store[key] = value
+        return None
+
+    monkeypatch.setattr(TaskInstance, "xcom_pull", mock_xcom_pull)
+    monkeypatch.setattr(TaskInstance, "xcom_push", mock_xcom_push)
+
+
+@pytest.fixture
+def mock_marc_as_json():
+    with open("tests/fixtures/record.json") as data:
+        return json.load(data)

--- a/tests/helpers/tasks.py
+++ b/tests/helpers/tasks.py
@@ -1,4 +1,5 @@
 import pytest
+import json
 from datetime import datetime
 
 from airflow import DAG
@@ -98,7 +99,7 @@ def mock_message():
 
 def marc_as_json():
     with open("tests/fixtures/record.json") as data:
-        return data.read()
+        return json.load(data)
 
 
 return_marc_tasks = [
@@ -113,20 +114,22 @@ def mock_task_instance(monkeypatch):
         key = kwargs.get("key")
         task_ids = kwargs.get("task_ids", [""])
         if key == "resources":
-            return [
-                "https://api.development.sinopia.io/resource/0000-1111-2222-3333",
-                "https://api.development.sinopia.io/resource/4444-5555-6666-7777",
-            ]
+            return """[
+                'https://api.development.sinopia.io/resource/0000-1111-2222-3333',
+                'https://api.development.sinopia.io/resource/4444-5555-6666-7777',
+            ]"""
         elif key == "messages":
             return mock_message()
         elif key in mock_resources and task_ids[0] == "sqs-message-parse":
-            return mock_resources[key]
+            return json.dumps(mock_resources[key])
         elif key == "overlay_resources":
-            return overlay_resources
+            return json.dumps(overlay_resources)
         elif task_ids[0] in return_marc_tasks:
-            return marc_as_json()
+            return json.dumps(marc_as_json())
         elif key == "new_resources":
-            return mock_resources
+            return json.dumps(mock_resources)
+        elif task_ids[0] == "process_symphony.download_marc":
+            return "tests/fixtures/record.mar"
         else:
             return mock_push_store[key]
 

--- a/tests/helpers/tasks.py
+++ b/tests/helpers/tasks.py
@@ -114,21 +114,21 @@ def mock_task_instance(monkeypatch):
         key = kwargs.get("key")
         task_ids = kwargs.get("task_ids", [""])
         if key == "resources":
-            return """[
-                'https://api.development.sinopia.io/resource/0000-1111-2222-3333',
-                'https://api.development.sinopia.io/resource/4444-5555-6666-7777',
-            ]"""
+            return [
+                "https://api.development.sinopia.io/resource/0000-1111-2222-3333",
+                "https://api.development.sinopia.io/resource/4444-5555-6666-7777",
+            ]
         elif key == "messages":
             return mock_message()
-        elif key in mock_resources and task_ids[0] == "sqs-message-parse":
+        elif key in mock_resources and task_ids == "sqs-message-parse":
             return json.dumps(mock_resources[key])
         elif key == "overlay_resources":
-            return json.dumps(overlay_resources)
-        elif task_ids[0] in return_marc_tasks:
+            return overlay_resources
+        elif task_ids in return_marc_tasks:
             return json.dumps(marc_as_json())
         elif key == "new_resources":
             return json.dumps(mock_resources)
-        elif task_ids[0] == "process_symphony.download_marc":
+        elif task_ids == "process_symphony.download_marc":
             return "tests/fixtures/record.mar"
         else:
             return mock_push_store[key]

--- a/tests/tasks/amazon/test_s3.py
+++ b/tests/tasks/amazon/test_s3.py
@@ -1,29 +1,13 @@
 """Test the AWS S3 tasks properly name and load files."""
 import json
 import pytest
-from datetime import datetime
 from unittest import mock
 
-from airflow import DAG
-from airflow.operators.dummy import DummyOperator
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
-from airflow.models.taskinstance import TaskInstance
 
 from ils_middleware.tasks.amazon.s3 import get_from_s3, send_to_s3
 
-
-def test_task():
-    return DummyOperator(
-        task_id="test_task",
-        dag=DAG(
-            "test_dag",
-            default_args={"owner": "airflow", "start_date": datetime(2021, 9, 20)},
-        ),
-    )
-
-
-task_instance = TaskInstance(test_task())
-mock_push_store = {}
+from tasks import test_task_instance, mock_task_instance, mock_marc_as_json
 
 
 @pytest.fixture
@@ -40,28 +24,6 @@ def mock_s3_hook(monkeypatch):
 
 
 @pytest.fixture
-def mock_task_instance(monkeypatch):
-    def mock_xcom_pull(*args, **kwargs):
-        key = kwargs.get("key")
-        if key == "resources":
-            return [
-                "http://example.com/rdf/0000-1111-2222-3333",
-                "http://example.com/rdf/4444-5555-6666-7777",
-            ]
-        else:
-            return mock_push_store[key]
-
-    def mock_xcom_push(*args, **kwargs):
-        key = kwargs.get("key")
-        value = kwargs.get("value")
-        mock_push_store[key] = value
-        return None
-
-    monkeypatch.setattr(TaskInstance, "xcom_pull", mock_xcom_pull)
-    monkeypatch.setattr(TaskInstance, "xcom_push", mock_xcom_push)
-
-
-@pytest.fixture
 def mock_s3_load_string():
     with mock.patch(
         "airflow.providers.amazon.aws.hooks.s3.S3Hook.load_string"
@@ -69,21 +31,15 @@ def mock_s3_load_string():
         yield mocked
 
 
-@pytest.fixture
-def mock_marc_as_json():
-    with open("tests/fixtures/record.json") as data:
-        return json.load(data)
-
-
 def test_get_from_s3(mock_s3_hook, mock_task_instance):
     """Test downloading a file from S3 into a temp file"""
-    get_from_s3(task_instance=task_instance)
+    get_from_s3(task_instance=test_task_instance())
     assert (
-        task_instance.xcom_pull(key="http://example.com/rdf/0000-1111-2222-3333")
+        test_task_instance().xcom_pull(key="http://example.com/rdf/0000-1111-2222-3333")
         == "tests/fixtures/record.mar"
     )
     assert (
-        task_instance.xcom_pull(key="http://example.com/rdf/4444-5555-6666-7777")
+        test_task_instance().xcom_pull(key="http://example.com/rdf/4444-5555-6666-7777")
         == "tests/fixtures/record.mar"
     )
 
@@ -91,17 +47,21 @@ def test_get_from_s3(mock_s3_hook, mock_task_instance):
 def test_send_to_s3(mock_s3_load_string, mock_task_instance, mock_marc_as_json):
     """Test sending a file to s3"""
 
-    send_to_s3(task_instance=task_instance)
+    send_to_s3(task_instance=test_task_instance())
     mock_s3_load_string.call_count == 2
     assert (
         json.loads(
-            task_instance.xcom_pull(key="http://example.com/rdf/0000-1111-2222-3333")
+            test_task_instance().xcom_pull(
+                key="http://example.com/rdf/0000-1111-2222-3333"
+            )
         )
         == mock_marc_as_json
     )
     assert (
         json.loads(
-            task_instance.xcom_pull(key="http://example.com/rdf/4444-5555-6666-7777")
+            test_task_instance().xcom_pull(
+                key="http://example.com/rdf/4444-5555-6666-7777"
+            )
         )
         == mock_marc_as_json
     )

--- a/tests/tasks/amazon/test_s3.py
+++ b/tests/tasks/amazon/test_s3.py
@@ -35,11 +35,11 @@ def test_get_from_s3(mock_s3_hook, mock_task_instance):
     """Test downloading a file from S3 into a temp file"""
     get_from_s3(task_instance=test_task_instance())
     assert (
-        test_task_instance().xcom_pull(key="http://example.com/rdf/0000-1111-2222-3333")
+        test_task_instance().xcom_pull(key="https://api.development.sinopia.io/resource/0000-1111-2222-3333")
         == "tests/fixtures/record.mar"
     )
     assert (
-        test_task_instance().xcom_pull(key="http://example.com/rdf/4444-5555-6666-7777")
+        test_task_instance().xcom_pull(key="https://api.development.sinopia.io/resource/4444-5555-6666-7777")
         == "tests/fixtures/record.mar"
     )
 
@@ -52,7 +52,7 @@ def test_send_to_s3(mock_s3_load_string, mock_task_instance, mock_marc_as_json):
     assert (
         json.loads(
             test_task_instance().xcom_pull(
-                key="http://example.com/rdf/0000-1111-2222-3333"
+                key="https://api.development.sinopia.io/resource/0000-1111-2222-3333"
             )
         )
         == mock_marc_as_json
@@ -60,7 +60,7 @@ def test_send_to_s3(mock_s3_load_string, mock_task_instance, mock_marc_as_json):
     assert (
         json.loads(
             test_task_instance().xcom_pull(
-                key="http://example.com/rdf/4444-5555-6666-7777"
+                key="https://api.development.sinopia.io/resource/4444-5555-6666-7777"
             )
         )
         == mock_marc_as_json

--- a/tests/tasks/amazon/test_s3.py
+++ b/tests/tasks/amazon/test_s3.py
@@ -7,7 +7,7 @@ from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 
 from ils_middleware.tasks.amazon.s3 import get_from_s3, send_to_s3
 
-from tasks import test_task_instance, mock_task_instance, mock_marc_as_json
+from tasks import test_task_instance, mock_task_instance, marc_as_json
 
 
 @pytest.fixture
@@ -35,27 +35,32 @@ def test_get_from_s3(mock_s3_hook, mock_task_instance):
     """Test downloading a file from S3 into a temp file"""
     get_from_s3(task_instance=test_task_instance())
     assert (
-        test_task_instance().xcom_pull(key="https://api.development.sinopia.io/resource/0000-1111-2222-3333")
+        test_task_instance().xcom_pull(
+            key="https://api.development.sinopia.io/resource/0000-1111-2222-3333"
+        )
         == "tests/fixtures/record.mar"
     )
     assert (
-        test_task_instance().xcom_pull(key="https://api.development.sinopia.io/resource/4444-5555-6666-7777")
+        test_task_instance().xcom_pull(
+            key="https://api.development.sinopia.io/resource/4444-5555-6666-7777"
+        )
         == "tests/fixtures/record.mar"
     )
 
 
-def test_send_to_s3(mock_s3_load_string, mock_task_instance, mock_marc_as_json):
+def test_send_to_s3(mock_s3_load_string, mock_task_instance):
     """Test sending a file to s3"""
 
     send_to_s3(task_instance=test_task_instance())
     mock_s3_load_string.call_count == 2
+    marc_json = json.loads(marc_as_json())
     assert (
         json.loads(
             test_task_instance().xcom_pull(
                 key="https://api.development.sinopia.io/resource/0000-1111-2222-3333"
             )
         )
-        == mock_marc_as_json
+        == marc_json
     )
     assert (
         json.loads(
@@ -63,5 +68,5 @@ def test_send_to_s3(mock_s3_load_string, mock_task_instance, mock_marc_as_json):
                 key="https://api.development.sinopia.io/resource/4444-5555-6666-7777"
             )
         )
-        == mock_marc_as_json
+        == marc_json
     )

--- a/tests/tasks/amazon/test_s3.py
+++ b/tests/tasks/amazon/test_s3.py
@@ -7,6 +7,7 @@ from unittest import mock
 from airflow import DAG
 from airflow.operators.dummy import DummyOperator
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.models.taskinstance import TaskInstance
 
 from ils_middleware.tasks.amazon.s3 import get_from_s3, send_to_s3
 
@@ -19,6 +20,10 @@ def test_task():
             default_args={"owner": "airflow", "start_date": datetime(2021, 9, 20)},
         ),
     )
+
+
+task_instance = TaskInstance(test_task())
+mock_push_store = {}
 
 
 @pytest.fixture
@@ -35,6 +40,25 @@ def mock_s3_hook(monkeypatch):
 
 
 @pytest.fixture
+def mock_task_instance(monkeypatch): # , mock_resources):
+    def mock_xcom_pull(*args, **kwargs):
+        key = kwargs.get("key")
+        if key == "resources":
+            return ["http://example.com/rdf/0000-1111-2222-3333", "http://example.com/rdf/4444-5555-6666-7777"]
+        else:
+            return mock_push_store[key]
+
+    def mock_xcom_push(*args, **kwargs):
+        key = kwargs.get("key")
+        value = kwargs.get("value")
+        mock_push_store[key] = value
+        return None
+
+    monkeypatch.setattr(TaskInstance, "xcom_pull", mock_xcom_pull)
+    monkeypatch.setattr(TaskInstance, "xcom_push", mock_xcom_push)
+
+
+@pytest.fixture
 def mock_s3_load_string():
     with mock.patch(
         "airflow.providers.amazon.aws.hooks.s3.S3Hook.load_string"
@@ -42,19 +66,24 @@ def mock_s3_load_string():
         yield mocked
 
 
-def test_get_from_s3(mock_env_vars, mock_s3_hook):
+def test_get_from_s3(mock_s3_hook, mock_task_instance):
     """Test downloading a file from S3 into a temp file"""
-    result = get_from_s3(instance_id="0000-1111-2222-3333")
-    assert json.loads(result) == {
-        "id": "0000-1111-2222-3333",
-        "temp_file": "path/to/temp/file",
-    }
+    get_from_s3(task_instance=task_instance)
+    assert task_instance.xcom_pull(key="http://example.com/rdf/0000-1111-2222-3333") == "path/to/temp/file"
+    assert task_instance.xcom_pull(key="http://example.com/rdf/4444-5555-6666-7777") == "path/to/temp/file"
 
 
-def test_send_to_s3(mock_env_vars, mock_s3_load_string):
-    """Test sending a file to s3"""
+# @pytest.fixture
+# def mock_instances():
+#     return [{
+#         "id": "0000-1111-2222-3333",
+#         "temp_file": "path/to/temp/file",
+#     }]
 
-    send_to_s3(
-        instance="""{"id": "0000-1111-2222-3333", "temp_file": "tests/fixtures/record.mar"}"""
-    )
-    mock_s3_load_string.assert_called_once()
+# def test_send_to_s3(mock_s3_load_string, mock_instances):
+#     """Test sending a file to s3"""
+
+#     send_to_s3(
+#         instances=mock_instances
+#     )
+#     mock_s3_load_string.assert_called_once()

--- a/tests/tasks/amazon/test_s3.py
+++ b/tests/tasks/amazon/test_s3.py
@@ -40,11 +40,14 @@ def mock_s3_hook(monkeypatch):
 
 
 @pytest.fixture
-def mock_task_instance(monkeypatch): # , mock_resources):
+def mock_task_instance(monkeypatch):
     def mock_xcom_pull(*args, **kwargs):
         key = kwargs.get("key")
         if key == "resources":
-            return ["http://example.com/rdf/0000-1111-2222-3333", "http://example.com/rdf/4444-5555-6666-7777"]
+            return [
+                "http://example.com/rdf/0000-1111-2222-3333",
+                "http://example.com/rdf/4444-5555-6666-7777",
+            ]
         else:
             return mock_push_store[key]
 
@@ -68,15 +71,21 @@ def mock_s3_load_string():
 
 @pytest.fixture
 def mock_marc_as_json():
-    with open('tests/fixtures/record.json') as data:
+    with open("tests/fixtures/record.json") as data:
         return json.load(data)
 
 
 def test_get_from_s3(mock_s3_hook, mock_task_instance):
     """Test downloading a file from S3 into a temp file"""
     get_from_s3(task_instance=task_instance)
-    assert task_instance.xcom_pull(key="http://example.com/rdf/0000-1111-2222-3333") == "tests/fixtures/record.mar"
-    assert task_instance.xcom_pull(key="http://example.com/rdf/4444-5555-6666-7777") == "tests/fixtures/record.mar"
+    assert (
+        task_instance.xcom_pull(key="http://example.com/rdf/0000-1111-2222-3333")
+        == "tests/fixtures/record.mar"
+    )
+    assert (
+        task_instance.xcom_pull(key="http://example.com/rdf/4444-5555-6666-7777")
+        == "tests/fixtures/record.mar"
+    )
 
 
 def test_send_to_s3(mock_s3_load_string, mock_task_instance, mock_marc_as_json):
@@ -84,5 +93,15 @@ def test_send_to_s3(mock_s3_load_string, mock_task_instance, mock_marc_as_json):
 
     send_to_s3(task_instance=task_instance)
     mock_s3_load_string.call_count == 2
-    assert json.loads(task_instance.xcom_pull(key="http://example.com/rdf/0000-1111-2222-3333")) == mock_marc_as_json
-    assert json.loads(task_instance.xcom_pull(key="http://example.com/rdf/4444-5555-6666-7777")) == mock_marc_as_json
+    assert (
+        json.loads(
+            task_instance.xcom_pull(key="http://example.com/rdf/0000-1111-2222-3333")
+        )
+        == mock_marc_as_json
+    )
+    assert (
+        json.loads(
+            task_instance.xcom_pull(key="http://example.com/rdf/4444-5555-6666-7777")
+        )
+        == mock_marc_as_json
+    )

--- a/tests/tasks/amazon/test_s3.py
+++ b/tests/tasks/amazon/test_s3.py
@@ -53,7 +53,7 @@ def test_send_to_s3(mock_s3_load_string, mock_task_instance):
 
     send_to_s3(task_instance=test_task_instance())
     mock_s3_load_string.call_count == 2
-    marc_json = json.loads(marc_as_json())
+    marc_json = marc_as_json()
     assert (
         json.loads(
             test_task_instance().xcom_pull(

--- a/tests/tasks/amazon/test_sqs.py
+++ b/tests/tasks/amazon/test_sqs.py
@@ -112,8 +112,12 @@ def mock_task_instance(monkeypatch, mock_message, mock_resource, mock_resources)
             return mock_resource
         elif key == "resources":
             return mock_resources
-        else:
+        elif key == "messages":
             return mock_message
+        else:
+            for resource in mock_resources:
+                if resource["resource_uri"] == key:
+                    return resource
 
     def mock_xcom_push(*args, **kwargs):
         return None
@@ -144,7 +148,8 @@ def test_parse_messages(
     task_instance = TaskInstance(task)
     result = parse_messages(task_instance=task_instance)
     assert result == "completed_parse"
-    assert task_instance.xcom_pull(key="resources") == mock_resources
+    for resource in mock_resources:
+        assert task_instance.xcom_pull(key=resource["resource_uri"]) == resource
 
 
 def test_get_resource(mock_get_resource, mock_resource):

--- a/tests/tasks/amazon/test_sqs.py
+++ b/tests/tasks/amazon/test_sqs.py
@@ -14,7 +14,7 @@ from ils_middleware.tasks.amazon.sqs import (
     get_resource,
 )
 
-from tasks import test_task_instance, mock_task_instance
+from tasks import test_task_instance, mock_task_instance  # noqa: F401
 
 
 @pytest.fixture
@@ -77,10 +77,11 @@ def mock_resources():
         "https://api.development.sinopia.io/resource/4444-5555-6666-7777",
     ]
 
-resources = []
 
 @pytest.fixture
 def mock_get_resource(monkeypatch):
+    resources = []
+
     def mock_get(uri, *args, **kwargs):
         resources.append(mock_resource(uri))
         response = requests.models.Response()
@@ -95,13 +96,19 @@ def mock_get_resource(monkeypatch):
 
 
 def test_parse_messages(
-    test_dag, mock_task_instance, mock_variable, mock_get_resource, mock_resources
+    test_dag,
+    mock_task_instance,  # noqa: F811
+    mock_variable,
+    mock_get_resource,
+    mock_resources,  # noqa: F811
 ):
     """Test parse_messages function."""
     result = parse_messages(task_instance=test_task_instance())
     assert result == "completed_parse"
     for resource in mock_resources:
-        assert test_task_instance().xcom_pull(key=resource).get("resource") == mock_resource(resource)
+        assert test_task_instance().xcom_pull(key=resource).get(
+            "resource"
+        ) == mock_resource(resource)
 
 
 def test_get_resource(mock_get_resource):

--- a/tests/tasks/sinopia/test_local_metadata.py
+++ b/tests/tasks/sinopia/test_local_metadata.py
@@ -28,8 +28,10 @@ def test_task():
         ),
     )
 
+
 task_instance = TaskInstance(test_task())
 mock_push_store = {}
+
 
 @pytest.fixture
 def mock_requests_post(monkeypatch, mocker: MockerFixture):
@@ -90,19 +92,19 @@ def mock_resources(mock_resource):
     return [
         {
             "resource_uri": "http://example.com/rdf/0000-1111-2222-3333",
-            "resource": mock_resource
+            "resource": mock_resource,
         },
         {
             "resource_uri": "http://example.com/rdf/4444-5555-6666-7777",
-            "resource": mock_resource
-        }
+            "resource": mock_resource,
+        },
     ]
 
+
 @pytest.fixture
-def mock_task_instance(mock_resources, monkeypatch): # , mock_resources):
+def mock_task_instance(mock_resources, monkeypatch):
     def mock_xcom_pull(*args, **kwargs):
         key = kwargs.get("key")
-        task_ids = kwargs.get("task_ids")
         if key == "resources":
             return mock_resources
         else:
@@ -119,9 +121,13 @@ def mock_task_instance(mock_resources, monkeypatch): # , mock_resources):
 
 
 def test_new_local_admin_metadata(
-    mock_requests_post, mock_airflow_variables, mock_uuid, mock_resource, mock_task_instance
+    mock_requests_post,
+    mock_airflow_variables,
+    mock_uuid,
+    mock_resource,
+    mock_task_instance,
 ):
-    local_admin_metadata_uri = new_local_admin_metadata(
+    new_local_admin_metadata(
         task_instance=task_instance,
         jwt="abcd1234efg",
         resource=str(mock_resource),
@@ -130,7 +136,7 @@ def test_new_local_admin_metadata(
 
     assert task_instance.xcom_pull(key="admin_metadata") == [
         "https://api.development.sinopia.io/resource/1a3cebda-34b9-4e15-bc79-f6a5f915ce76",
-        "https://api.development.sinopia.io/resource/1a3cebda-34b9-4e15-bc79-f6a5f915ce76"
+        "https://api.development.sinopia.io/resource/1a3cebda-34b9-4e15-bc79-f6a5f915ce76",
     ]
 
 

--- a/tests/tasks/sinopia/test_local_metadata.py
+++ b/tests/tasks/sinopia/test_local_metadata.py
@@ -50,7 +50,7 @@ def mock_airflow_variables(monkeypatch):
     def mock_get(*args, **kwargs):
         if args[0].startswith("sinopia_user"):
             return "ils_middleware"
-        if args[0].startswith("sinopia_api_uri"):
+        if args[0].startswith("dev_sinopia_api_uri"):
             return "https://api.development.sinopia.io/resource"
 
     monkeypatch.setattr(Variable, "get", mock_get)
@@ -130,8 +130,6 @@ def test_new_local_admin_metadata(
     new_local_admin_metadata(
         task_instance=task_instance,
         jwt="abcd1234efg",
-        resource=str(mock_resource),
-        instance_uri="https://api.development.sinopia.io/resource/tyu8889asdf",
     )
 
     assert task_instance.xcom_pull(key="admin_metadata") == [

--- a/tests/tasks/sinopia/test_local_metadata.py
+++ b/tests/tasks/sinopia/test_local_metadata.py
@@ -33,7 +33,7 @@ def mock_airflow_variables(monkeypatch):
     def mock_get(*args, **kwargs):
         if args[0].startswith("sinopia_user"):
             return "ils_middleware"
-        if args[0].startswith("dev_sinopia_api_uri"):
+        if args[0].startswith("sinopia_api_uri"):
             return "https://api.development.sinopia.io/resource"
 
     monkeypatch.setattr(Variable, "get", mock_get)

--- a/tests/tasks/sinopia/test_local_metadata.py
+++ b/tests/tasks/sinopia/test_local_metadata.py
@@ -4,11 +4,6 @@ import uuid
 import pytest
 import rdflib
 import requests  # type: ignore
-from datetime import datetime
-
-from airflow import DAG
-from airflow.operators.dummy import DummyOperator
-from airflow.models.taskinstance import TaskInstance
 
 from airflow.models import Variable
 from pytest_mock import MockerFixture
@@ -18,7 +13,7 @@ from ils_middleware.tasks.sinopia.local_metadata import (
     new_local_admin_metadata,
 )
 
-from tasks import test_task_instance, mock_task_instance, mock_marc_as_json
+from tasks import test_task_instance, mock_task_instance  # noqa: F401
 
 
 @pytest.fixture
@@ -56,16 +51,27 @@ def test_new_local_admin_metadata(
     mock_requests_post,
     mock_airflow_variables,
     mock_uuid,
-    mock_task_instance,
+    mock_task_instance,  # noqa: F811
 ):
     new_local_admin_metadata(
         task_instance=test_task_instance(),
         jwt="abcd1234efg",
     )
 
-    assert test_task_instance().xcom_pull(key="https://api.development.sinopia.io/resource/0000-1111-2222-3333") == "https://api.development.sinopia.io/resource/1a3cebda-34b9-4e15-bc79-f6a5f915ce76"
-    assert test_task_instance().xcom_pull(key="https://api.development.sinopia.io/resource/4444-5555-6666-7777") == "https://api.development.sinopia.io/resource/1a3cebda-34b9-4e15-bc79-f6a5f915ce76"
-    
+    assert (
+        test_task_instance().xcom_pull(
+            key="https://api.development.sinopia.io/resource/0000-1111-2222-3333"
+        )
+        == "https://api.development.sinopia.io/resource/1a3cebda-34b9-4e15-bc79-f6a5f915ce76"
+    )
+
+    assert (
+        test_task_instance().xcom_pull(
+            key="https://api.development.sinopia.io/resource/4444-5555-6666-7777"
+        )
+        == "https://api.development.sinopia.io/resource/1a3cebda-34b9-4e15-bc79-f6a5f915ce76"
+    )
+
 
 def test_create_admin_metadata():
     admin_metadata = rdflib.Graph()

--- a/tests/tasks/sinopia/test_local_metadata.py
+++ b/tests/tasks/sinopia/test_local_metadata.py
@@ -63,11 +63,9 @@ def test_new_local_admin_metadata(
         jwt="abcd1234efg",
     )
 
-    assert test_task_instance().xcom_pull(key="admin_metadata") == [
-        "https://api.development.sinopia.io/resource/1a3cebda-34b9-4e15-bc79-f6a5f915ce76",
-        "https://api.development.sinopia.io/resource/1a3cebda-34b9-4e15-bc79-f6a5f915ce76",
-    ]
-
+    assert test_task_instance().xcom_pull(key="https://api.development.sinopia.io/resource/0000-1111-2222-3333") == "https://api.development.sinopia.io/resource/1a3cebda-34b9-4e15-bc79-f6a5f915ce76"
+    assert test_task_instance().xcom_pull(key="https://api.development.sinopia.io/resource/4444-5555-6666-7777") == "https://api.development.sinopia.io/resource/1a3cebda-34b9-4e15-bc79-f6a5f915ce76"
+    
 
 def test_create_admin_metadata():
     admin_metadata = rdflib.Graph()

--- a/tests/tasks/sinopia/test_metadata_check.py
+++ b/tests/tasks/sinopia/test_metadata_check.py
@@ -102,11 +102,11 @@ def mock_task_instance(monkeypatch):
     def mock_xcom_pull(*args, **kwargs):
         key = kwargs.get("key")
         if key == "resources":
-            return """[
-                'http://example.com/rdf/0000-1111-2222-3333',
-                'http://example.com/rdf/4444-5555-6666-7777',
-                'https://api.sinopia.io/resource/oprt5531',
-            ]"""
+            return [
+                "http://example.com/rdf/0000-1111-2222-3333",
+                "http://example.com/rdf/4444-5555-6666-7777",
+                "https://api.sinopia.io/resource/oprt5531",
+            ]
         else:
             return mock_push_store[key]
 

--- a/tests/tasks/sinopia/test_metadata_check.py
+++ b/tests/tasks/sinopia/test_metadata_check.py
@@ -102,11 +102,11 @@ def mock_task_instance(monkeypatch):
     def mock_xcom_pull(*args, **kwargs):
         key = kwargs.get("key")
         if key == "resources":
-            return [
-                "http://example.com/rdf/0000-1111-2222-3333",
-                "http://example.com/rdf/4444-5555-6666-7777",
-                "https://api.sinopia.io/resource/oprt5531",
-            ]
+            return """[
+                'http://example.com/rdf/0000-1111-2222-3333',
+                'http://example.com/rdf/4444-5555-6666-7777',
+                'https://api.sinopia.io/resource/oprt5531',
+            ]"""
         else:
             return mock_push_store[key]
 

--- a/tests/tasks/sinopia/test_metadata_check.py
+++ b/tests/tasks/sinopia/test_metadata_check.py
@@ -25,7 +25,7 @@ def test_task():
 
 
 task_instance = TaskInstance(test_task())
-mock_push_store = {}
+mock_push_store: dict = {}
 
 admin_metadata = [
     {

--- a/tests/tasks/sinopia/test_metadata_check.py
+++ b/tests/tasks/sinopia/test_metadata_check.py
@@ -101,9 +101,12 @@ def mock_datetime(monkeypatch):
 def mock_task_instance(monkeypatch):
     def mock_xcom_pull(*args, **kwargs):
         key = kwargs.get("key")
-        task_ids = kwargs.get("task_ids")
         if key == "resources":
-            return ["http://example.com/rdf/0000-1111-2222-3333", "http://example.com/rdf/4444-5555-6666-7777", "https://api.sinopia.io/resource/oprt5531"]
+            return [
+                "http://example.com/rdf/0000-1111-2222-3333",
+                "http://example.com/rdf/4444-5555-6666-7777",
+                "https://api.sinopia.io/resource/oprt5531",
+            ]
         else:
             return mock_push_store[key]
 

--- a/tests/tasks/sinopia/test_rdf2marc.py
+++ b/tests/tasks/sinopia/test_rdf2marc.py
@@ -27,10 +27,52 @@ def test_task():
     return DummyOperator(task_id="test", dag=test_dag)
 
 
+task_instance = TaskInstance(test_task())
+
+
 @pytest.fixture
-def mock_task_instance(monkeypatch):
+def mock_resource():
+    return {
+        "user": "jpnelson",
+        "group": "stanford",
+        "editGroups": ["other", "pcc"],
+        "templateId": "ld4p:RT:bf2:Monograph:Instance:Un-nested",
+        "types": ["http://id.loc.gov/ontologies/bibframe/Instance"],
+        "bfAdminMetadataRefs": [
+            "https://api.development.sinopia.io/resource/7f775ec2-4fe8-48a6-9cb4-5b218f9960f1",
+            "https://api.development.sinopia.io/resource/bc9e9939-45b3-4122-9b6d-d800c130c576",
+        ],
+        "bfItemRefs": [],
+        "bfInstanceRefs": [],
+        "bfWorkRefs": [
+            "https://api.development.sinopia.io/resource/6497a461-42dc-42bf-b433-5e47c73f7e89"
+        ],
+        "id": "7b55e6f7-f91e-4c7a-bbcd-c074485ad18d",
+        "uri": "https://api.development.sinopia.io/resource/7b55e6f7-f91e-4c7a-bbcd-c074485ad18d",
+        "timestamp": "2021-10-29T20:30:58.821Z",
+    }
+
+
+@pytest.fixture
+def mock_resources(mock_resource):
+    return [
+        {
+            "email": "dscully@stanford.edu",
+            "resource_uri": "http://example.com/rdf/0000-1111-2222-3333",
+            "resource": mock_resource,
+        },
+        {
+            "email": "fmulder@stanford.edu",
+            "resource_uri": "http://example.com/rdf/0000-1111-2222-3333",
+            "resource": mock_resource,
+        },
+    ]
+
+
+@pytest.fixture
+def mock_task_instance(monkeypatch, mock_resources):
     def mock_xcom_pull(*args, **kwargs):
-        return "http://example.com/rdf/0000-1111-2222-3333"
+        return mock_resources
 
     monkeypatch.setattr(TaskInstance, "xcom_pull", mock_xcom_pull)
 
@@ -43,15 +85,16 @@ def mock_lambda(monkeypatch):
     monkeypatch.setattr(AwsLambdaHook, "invoke_lambda", mock_invoke_lambda)
 
 
-def test_Rdf2Marc(mock_task_instance, mock_lambda):
-    payload = {"instance_uri": "http://example.com/rdf/0000-1111-2222-3333"}
+@pytest.fixture
+def mock_complete_results():
+    return {
+        "complete": ["http://example.com/rdf/0000-1111-2222-3333", "http://example.com/rdf/0000-1111-2222-3333"],
+        "errors": []
+    }
 
-    assert (
-        Rdf2Marc(
-            instance_uri="http://example.com/rdf/0000-1111-2222-3333", payload=payload
-        )
-        == "0000-1111-2222-3333"
-    )
+def test_Rdf2Marc(mock_task_instance, mock_lambda, mock_complete_results):
+    # payload = {"instance_uri": "http://example.com/rdf/0000-1111-2222-3333"}
+    assert Rdf2Marc(task_instance=task_instance) == mock_complete_results
 
 
 @pytest.fixture
@@ -68,6 +111,22 @@ def mock_failed_lambda(monkeypatch):
     monkeypatch.setattr(AwsLambdaHook, "invoke_lambda", mock_invoke_lambda)
 
 
-def test_Rdf2Marc_LambdaError(mock_failed_lambda):
-    with pytest.raises(Exception, match="RDF2MARC conversion failed"):
-        Rdf2Marc(instance_uri="http://example.com/rdf/0000-1111-2222-3333")
+@pytest.fixture
+def mock_error_results():
+    return {
+        "complete": [],
+        "errors": [
+            {
+                "instance_uri": "http://example.com/rdf/0000-1111-2222-3333",
+                "message": "RDF2MARC conversion failed for http://example.com/rdf/0000-1111-2222-3333, error: AdminMetadata (bf:adminMetadata) not specified for Instance"
+            },
+            {
+                "instance_uri": "http://example.com/rdf/0000-1111-2222-3333",
+                "message": "RDF2MARC conversion failed for http://example.com/rdf/0000-1111-2222-3333, error: AdminMetadata (bf:adminMetadata) not specified for Instance"
+            }
+        ]
+    }
+
+
+def test_Rdf2Marc_LambdaError(mock_task_instance, mock_failed_lambda, mock_error_results):
+    assert Rdf2Marc(task_instance=task_instance) == mock_error_results

--- a/tests/tasks/sinopia/test_rdf2marc.py
+++ b/tests/tasks/sinopia/test_rdf2marc.py
@@ -1,18 +1,12 @@
 """Test Symphony Operators and functions."""
 import io
-
 import pytest
-from datetime import datetime
-
-from airflow import DAG
 
 from airflow.contrib.hooks.aws_lambda_hook import AwsLambdaHook
-from airflow.models.taskinstance import TaskInstance
-from airflow.operators.dummy import DummyOperator
 
 from ils_middleware.tasks.sinopia.rdf2marc import Rdf2Marc
 
-from tasks import test_task_instance, mock_task_instance
+from tasks import test_task_instance, mock_task_instance  # noqa: F401
 
 mock_200_response = {
     "Payload": io.StringIO("{}"),
@@ -31,14 +25,18 @@ def mock_lambda(monkeypatch):
     monkeypatch.setattr(AwsLambdaHook, "invoke_lambda", mock_invoke_lambda)
 
 
-def test_Rdf2Marc(mock_task_instance, mock_lambda):
+def test_Rdf2Marc(mock_task_instance, mock_lambda):  # noqa: F811
     Rdf2Marc(task_instance=task_instance)
     assert (
-        task_instance.xcom_pull(key="https://api.development.sinopia.io/resource/0000-1111-2222-3333")
+        task_instance.xcom_pull(
+            key="https://api.development.sinopia.io/resource/0000-1111-2222-3333"
+        )
         == "airflow/0000-1111-2222-3333/record.mar"
     )
     assert (
-        task_instance.xcom_pull(key="https://api.development.sinopia.io/resource/4444-5555-6666-7777")
+        task_instance.xcom_pull(
+            key="https://api.development.sinopia.io/resource/4444-5555-6666-7777"
+        )
         == "airflow/4444-5555-6666-7777/record.mar"
     )
 
@@ -57,7 +55,7 @@ def mock_failed_lambda(monkeypatch):
     monkeypatch.setattr(AwsLambdaHook, "invoke_lambda", mock_invoke_lambda)
 
 
-def test_Rdf2Marc_LambdaError(mock_task_instance, mock_failed_lambda):
+def test_Rdf2Marc_LambdaError(mock_task_instance, mock_failed_lambda):  # noqa: F811
     Rdf2Marc(task_instance=task_instance)
     err1 = task_instance.xcom_pull(
         key="https://api.development.sinopia.io/resource/0000-1111-2222-3333"

--- a/tests/tasks/sinopia/test_update_resource.py
+++ b/tests/tasks/sinopia/test_update_resource.py
@@ -1,16 +1,11 @@
 import pytest
 import requests  # type: ignore
-from datetime import datetime
-
-from airflow import DAG
-from airflow.operators.dummy import DummyOperator
-from airflow.models.taskinstance import TaskInstance
 
 from pytest_mock import MockerFixture
 
 from ils_middleware.tasks.sinopia.update_resource import update_resource_new_metadata
 
-from tasks import test_task_instance, mock_task_instance, mock_marc_as_json
+from tasks import test_task_instance, mock_task_instance  # noqa: F401
 
 SINOPIA_API = {
     "https://api.development.sinopia.io/resource/0000-1111-2222-3333": {
@@ -65,7 +60,7 @@ def mock_requests(monkeypatch, mocker: MockerFixture):
     monkeypatch.setattr(requests, "put", mock_put)
 
 
-def test_update_resource(mock_requests, mock_task_instance):
+def test_update_resource(mock_requests, mock_task_instance):  # noqa: F811
     update_resource_new_metadata(
         task_instance=task_instance,
         jwt="3445676",

--- a/tests/tasks/sinopia/test_update_resource.py
+++ b/tests/tasks/sinopia/test_update_resource.py
@@ -43,6 +43,7 @@ def test_task():
         ),
     )
 
+
 task_instance = TaskInstance(test_task())
 mock_push_store = {}
 
@@ -103,25 +104,24 @@ def mock_resources(mock_resource):
         {
             "resource_uri": "http://example.com/rdf/0000-1111-2222-3333",
             "metadata_uri": "https://api.development.sinopia.io/resource/1a3cebda-34b9-4e15-bc79-f6a5f915ce76",
-            "resource": mock_resource
+            "resource": mock_resource,
         },
         {
             "resource_uri": "http://example.com/rdf/4444-5555-6666-7777",
             "metadata_uri": "https://api.development.sinopia.io/resource/1a3cebda-34b9-4e15-bc79-f6a5f915ce76",
-            "resource": mock_resource
+            "resource": mock_resource,
         },
         {
             "resource_uri": "https://s.io/resources/11ec",
             "metadata_uri": "https://s.io/resources/b5db",
-        }
+        },
     ]
 
 
 @pytest.fixture
-def mock_task_instance(mock_resources, monkeypatch): # , mock_resources):
+def mock_task_instance(mock_resources, monkeypatch):
     def mock_xcom_pull(*args, **kwargs):
         key = kwargs.get("key")
-        task_ids = kwargs.get("task_ids")
         if key == "resources":
             return mock_resources
         else:
@@ -138,7 +138,7 @@ def mock_task_instance(mock_resources, monkeypatch): # , mock_resources):
 
 
 def test_update_resource(mock_requests, mock_task_instance):
-    result = update_resource_new_metadata(
+    update_resource_new_metadata(
         task_instance=task_instance,
         jwt="3445676",
     )

--- a/tests/tasks/sinopia/test_update_resource.py
+++ b/tests/tasks/sinopia/test_update_resource.py
@@ -10,8 +10,10 @@ from pytest_mock import MockerFixture
 
 from ils_middleware.tasks.sinopia.update_resource import update_resource_new_metadata
 
+from tasks import test_task_instance, mock_task_instance, mock_marc_as_json
+
 SINOPIA_API = {
-    "http://example.com/rdf/0000-1111-2222-3333": {
+    "https://api.development.sinopia.io/resource/0000-1111-2222-3333": {
         "data": [
             {
                 "@id": "https://s.io/resources/f3d34054",
@@ -20,7 +22,7 @@ SINOPIA_API = {
         ],
         "bfAdminMetadataRefs": [],
     },
-    "http://example.com/rdf/4444-5555-6666-7777": {
+    "https://api.development.sinopia.io/resource/4444-5555-6666-7777": {
         "data": [
             {
                 "@id": "https://s.io/resources/acde48001122",
@@ -33,19 +35,7 @@ SINOPIA_API = {
 
 SINOPIA_API_ERRORS = ["https://s.io/resources/acde48001122"]
 
-
-def test_task():
-    return DummyOperator(
-        task_id="test_task",
-        dag=DAG(
-            "test_dag",
-            default_args={"owner": "airflow", "start_date": datetime(2021, 9, 20)},
-        ),
-    )
-
-
-task_instance = TaskInstance(test_task())
-mock_push_store = {}
+task_instance = test_task_instance()
 
 
 @pytest.fixture
@@ -75,68 +65,6 @@ def mock_requests(monkeypatch, mocker: MockerFixture):
     monkeypatch.setattr(requests, "put", mock_put)
 
 
-@pytest.fixture
-def mock_resource():
-    return {
-        "user": "jpnelson",
-        "group": "stanford",
-        "editGroups": ["other", "pcc"],
-        "templateId": "ld4p:RT:bf2:Monograph:Instance:Un-nested",
-        "types": ["http://id.loc.gov/ontologies/bibframe/Instance"],
-        "bfAdminMetadataRefs": [
-            "https://api.development.sinopia.io/resource/7f775ec2-4fe8-48a6-9cb4-5b218f9960f1",
-            "https://api.development.sinopia.io/resource/bc9e9939-45b3-4122-9b6d-d800c130c576",
-        ],
-        "bfItemRefs": [],
-        "bfInstanceRefs": [],
-        "bfWorkRefs": [
-            "https://api.development.sinopia.io/resource/6497a461-42dc-42bf-b433-5e47c73f7e89"
-        ],
-        "id": "7b55e6f7-f91e-4c7a-bbcd-c074485ad18d",
-        "uri": "https://api.development.sinopia.io/resource/7b55e6f7-f91e-4c7a-bbcd-c074485ad18d",
-        "timestamp": "2021-10-29T20:30:58.821Z",
-    }
-
-
-@pytest.fixture
-def mock_resources(mock_resource):
-    return [
-        {
-            "resource_uri": "http://example.com/rdf/0000-1111-2222-3333",
-            "metadata_uri": "https://api.development.sinopia.io/resource/1a3cebda-34b9-4e15-bc79-f6a5f915ce76",
-            "resource": mock_resource,
-        },
-        {
-            "resource_uri": "http://example.com/rdf/4444-5555-6666-7777",
-            "metadata_uri": "https://api.development.sinopia.io/resource/1a3cebda-34b9-4e15-bc79-f6a5f915ce76",
-            "resource": mock_resource,
-        },
-        {
-            "resource_uri": "https://s.io/resources/11ec",
-            "metadata_uri": "https://s.io/resources/b5db",
-        },
-    ]
-
-
-@pytest.fixture
-def mock_task_instance(mock_resources, monkeypatch):
-    def mock_xcom_pull(*args, **kwargs):
-        key = kwargs.get("key")
-        if key == "resources":
-            return mock_resources
-        else:
-            return mock_push_store[key]
-
-    def mock_xcom_push(*args, **kwargs):
-        key = kwargs.get("key")
-        value = kwargs.get("value")
-        mock_push_store[key] = value
-        return None
-
-    monkeypatch.setattr(TaskInstance, "xcom_pull", mock_xcom_pull)
-    monkeypatch.setattr(TaskInstance, "xcom_push", mock_xcom_push)
-
-
 def test_update_resource(mock_requests, mock_task_instance):
     update_resource_new_metadata(
         task_instance=task_instance,
@@ -144,27 +72,4 @@ def test_update_resource(mock_requests, mock_task_instance):
     )
 
     assert len(task_instance.xcom_pull(key="updated_resources")) == 2
-    assert len(task_instance.xcom_pull(key="resource_not_found")) == 1
-
-
-# def test_missing_resource_uri(mock_requests, mock_task_instance):
-#     with pytest.raises(
-#         Exception, match="https://s.io/resources/11ec retrieval error 404"
-#     ):
-#         update_resource_new_metadata(
-#             jwt="33446",
-#             resource_uri="https://s.io/resources/11ec",
-#             metadata_uri="https://s.io/resources/b5db",
-#         )
-
-
-# def test_bad_put_call_for_resource(mock_requests, mock_task_instance):
-#     with pytest.raises(
-#         Exception,
-#         match="Failed to update https://s.io/resources/acde48001122, status code 500",
-#     ):
-#         update_resource_new_metadata(
-#             jwt="5677sce",
-#             resource_uri="https://s.io/resources/acde48001122",
-#             metadata_uri="https://s.io/resources/7a669b8c",
-#         )
+    assert len(task_instance.xcom_pull(key="resource_not_found")) == 0

--- a/tests/tasks/sinopia/test_update_resource.py
+++ b/tests/tasks/sinopia/test_update_resource.py
@@ -1,12 +1,17 @@
 import pytest
 import requests  # type: ignore
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators.dummy import DummyOperator
+from airflow.models.taskinstance import TaskInstance
 
 from pytest_mock import MockerFixture
 
 from ils_middleware.tasks.sinopia.update_resource import update_resource_new_metadata
 
 SINOPIA_API = {
-    "https://s.io/resources/f3d34054": {
+    "http://example.com/rdf/0000-1111-2222-3333": {
         "data": [
             {
                 "@id": "https://s.io/resources/f3d34054",
@@ -15,7 +20,7 @@ SINOPIA_API = {
         ],
         "bfAdminMetadataRefs": [],
     },
-    "https://s.io/resources/acde48001122": {
+    "http://example.com/rdf/4444-5555-6666-7777": {
         "data": [
             {
                 "@id": "https://s.io/resources/acde48001122",
@@ -27,6 +32,19 @@ SINOPIA_API = {
 }
 
 SINOPIA_API_ERRORS = ["https://s.io/resources/acde48001122"]
+
+
+def test_task():
+    return DummyOperator(
+        task_id="test_task",
+        dag=DAG(
+            "test_dag",
+            default_args={"owner": "airflow", "start_date": datetime(2021, 9, 20)},
+        ),
+    )
+
+task_instance = TaskInstance(test_task())
+mock_push_store = {}
 
 
 @pytest.fixture
@@ -56,34 +74,97 @@ def mock_requests(monkeypatch, mocker: MockerFixture):
     monkeypatch.setattr(requests, "put", mock_put)
 
 
-def test_successful_update_resource(mock_requests):
+@pytest.fixture
+def mock_resource():
+    return {
+        "user": "jpnelson",
+        "group": "stanford",
+        "editGroups": ["other", "pcc"],
+        "templateId": "ld4p:RT:bf2:Monograph:Instance:Un-nested",
+        "types": ["http://id.loc.gov/ontologies/bibframe/Instance"],
+        "bfAdminMetadataRefs": [
+            "https://api.development.sinopia.io/resource/7f775ec2-4fe8-48a6-9cb4-5b218f9960f1",
+            "https://api.development.sinopia.io/resource/bc9e9939-45b3-4122-9b6d-d800c130c576",
+        ],
+        "bfItemRefs": [],
+        "bfInstanceRefs": [],
+        "bfWorkRefs": [
+            "https://api.development.sinopia.io/resource/6497a461-42dc-42bf-b433-5e47c73f7e89"
+        ],
+        "id": "7b55e6f7-f91e-4c7a-bbcd-c074485ad18d",
+        "uri": "https://api.development.sinopia.io/resource/7b55e6f7-f91e-4c7a-bbcd-c074485ad18d",
+        "timestamp": "2021-10-29T20:30:58.821Z",
+    }
+
+
+@pytest.fixture
+def mock_resources(mock_resource):
+    return [
+        {
+            "resource_uri": "http://example.com/rdf/0000-1111-2222-3333",
+            "metadata_uri": "https://api.development.sinopia.io/resource/1a3cebda-34b9-4e15-bc79-f6a5f915ce76",
+            "resource": mock_resource
+        },
+        {
+            "resource_uri": "http://example.com/rdf/4444-5555-6666-7777",
+            "metadata_uri": "https://api.development.sinopia.io/resource/1a3cebda-34b9-4e15-bc79-f6a5f915ce76",
+            "resource": mock_resource
+        },
+        {
+            "resource_uri": "https://s.io/resources/11ec",
+            "metadata_uri": "https://s.io/resources/b5db",
+        }
+    ]
+
+
+@pytest.fixture
+def mock_task_instance(mock_resources, monkeypatch): # , mock_resources):
+    def mock_xcom_pull(*args, **kwargs):
+        key = kwargs.get("key")
+        task_ids = kwargs.get("task_ids")
+        if key == "resources":
+            return mock_resources
+        else:
+            return mock_push_store[key]
+
+    def mock_xcom_push(*args, **kwargs):
+        key = kwargs.get("key")
+        value = kwargs.get("value")
+        mock_push_store[key] = value
+        return None
+
+    monkeypatch.setattr(TaskInstance, "xcom_pull", mock_xcom_pull)
+    monkeypatch.setattr(TaskInstance, "xcom_push", mock_xcom_push)
+
+
+def test_update_resource(mock_requests, mock_task_instance):
     result = update_resource_new_metadata(
+        task_instance=task_instance,
         jwt="3445676",
-        resource_uri="https://s.io/resources/f3d34054",
-        metadata_uri="https://s.io/resources/38eb",
     )
 
-    assert result.startswith("resource_updated")
+    assert len(task_instance.xcom_pull(key="updated_resources")) == 2
+    assert len(task_instance.xcom_pull(key="resource_not_found")) == 1
 
 
-def test_missing_resource_uri(mock_requests):
-    with pytest.raises(
-        Exception, match="https://s.io/resources/11ec retrieval error 404"
-    ):
-        update_resource_new_metadata(
-            jwt="33446",
-            resource_uri="https://s.io/resources/11ec",
-            metadata_uri="https://s.io/resources/b5db",
-        )
+# def test_missing_resource_uri(mock_requests, mock_task_instance):
+#     with pytest.raises(
+#         Exception, match="https://s.io/resources/11ec retrieval error 404"
+#     ):
+#         update_resource_new_metadata(
+#             jwt="33446",
+#             resource_uri="https://s.io/resources/11ec",
+#             metadata_uri="https://s.io/resources/b5db",
+#         )
 
 
-def test_bad_put_call_for_resource(mock_requests):
-    with pytest.raises(
-        Exception,
-        match="Failed to update https://s.io/resources/acde48001122, status code 500",
-    ):
-        update_resource_new_metadata(
-            jwt="5677sce",
-            resource_uri="https://s.io/resources/acde48001122",
-            metadata_uri="https://s.io/resources/7a669b8c",
-        )
+# def test_bad_put_call_for_resource(mock_requests, mock_task_instance):
+#     with pytest.raises(
+#         Exception,
+#         match="Failed to update https://s.io/resources/acde48001122, status code 500",
+#     ):
+#         update_resource_new_metadata(
+#             jwt="5677sce",
+#             resource_uri="https://s.io/resources/acde48001122",
+#             metadata_uri="https://s.io/resources/7a669b8c",
+#         )

--- a/tests/tasks/symphony/test_mod_json.py
+++ b/tests/tasks/symphony/test_mod_json.py
@@ -1,46 +1,65 @@
 """Tests functions for modifying JSON to Symphony JSON."""
 import json
 import pytest
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators.dummy import DummyOperator
+from airflow.models.taskinstance import TaskInstance
 
 from ils_middleware.tasks.symphony.mod_json import to_symphony_json
 
 
+def test_task():
+    return DummyOperator(
+        task_id="test_task",
+        dag=DAG(
+            "test_dag",
+            default_args={"owner": "airflow", "start_date": datetime(2021, 9, 20)},
+        ),
+    )
+
+
+task_instance = TaskInstance(test_task())
+mock_push_store = {}
+
+
 @pytest.fixture
-def org_json():
-    return {
-        "leader": "01176nam a2200241uu 4500",
-        "fields": [
-            {"008": "200915s1998    uk                  eng||"},
-            {
-                "245": {
-                    "ind1": "1",
-                    "ind2": "0",
-                    "subfields": [
-                        {"a": "Hildegard von Bingen's Physica"},
-                        {
-                            "b": "the complete English translation of "
-                            "her classic work on health and "
-                            "healing"
-                        },
-                        {
-                            "c": "translated from the Latin by "
-                            "Priscilla Throop ; illustrations by "
-                            "Mary Elder Jacobsen"
-                        },
-                    ],
-                }
-            },
-        ],
-    }
+def mock_marc_as_json():
+    with open('tests/fixtures/record.json') as data:
+        return data.read()
 
 
-def test_to_symphony_json(org_json):
-    symphony_json = to_symphony_json(marc_json=json.dumps(org_json))
+@pytest.fixture
+def mock_task_instance(mock_marc_as_json,monkeypatch): # , mock_resources):
+    def mock_xcom_pull(*args, **kwargs):
+        key = kwargs.get("key")
+        task_ids = kwargs.get("task_ids")
+        if key == "resources":
+            return ["http://example.com/rdf/0000-1111-2222-3333", "http://example.com/rdf/4444-5555-6666-7777"]
+        elif task_ids == ["process_symphony.marc_json_to_s3"]:
+            return mock_marc_as_json
+        else:
+            return mock_push_store[key]
+
+    def mock_xcom_push(*args, **kwargs):
+        key = kwargs.get("key")
+        value = kwargs.get("value")
+        mock_push_store[key] = value
+        return None
+
+    monkeypatch.setattr(TaskInstance, "xcom_pull", mock_xcom_pull)
+    monkeypatch.setattr(TaskInstance, "xcom_push", mock_xcom_push)
+
+
+def test_to_symphony_json(mock_task_instance):
+    to_symphony_json(task_instance=task_instance)
+    symphony_json = task_instance.xcom_pull(key="http://example.com/rdf/0000-1111-2222-3333")
     assert symphony_json["standard"].startswith("MARC21")
-    assert symphony_json["leader"].startswith("01176nam a2200241uu 4500")
-    assert symphony_json["fields"][0]["tag"] == "008"
-    assert symphony_json["fields"][1]["inds"] == "10"
-    assert symphony_json["fields"][1]["subfields"][0]["code"] == "a"
-    assert symphony_json["fields"][1]["subfields"][0]["data"].startswith(
+    assert symphony_json["leader"].startswith("01455nam a2200277uu 4500")
+    assert symphony_json["fields"][0]["tag"] == "003"
+    assert symphony_json["fields"][2]["subfields"][0]["code"] == "a"
+    assert symphony_json["fields"][2]["subfields"][0]["data"] == "981811"
+    assert symphony_json["fields"][7]["subfields"][0]["data"].startswith(
         "Hildegard von Bingen's Physica"
     )

--- a/tests/tasks/symphony/test_mod_json.py
+++ b/tests/tasks/symphony/test_mod_json.py
@@ -1,63 +1,15 @@
 """Tests functions for modifying JSON to Symphony JSON."""
-import pytest
-from datetime import datetime
-
-from airflow import DAG
-from airflow.operators.dummy import DummyOperator
-from airflow.models.taskinstance import TaskInstance
-
 from ils_middleware.tasks.symphony.mod_json import to_symphony_json
 
+from tasks import test_task_instance, mock_task_instance  # noqa: F401
 
-def test_task():
-    return DummyOperator(
-        task_id="test_task",
-        dag=DAG(
-            "test_dag",
-            default_args={"owner": "airflow", "start_date": datetime(2021, 9, 20)},
-        ),
-    )
+task_instance = test_task_instance()
 
 
-task_instance = TaskInstance(test_task())
-mock_push_store = {}
-
-
-@pytest.fixture
-def mock_marc_as_json():
-    with open("tests/fixtures/record.json") as data:
-        return data.read()
-
-
-@pytest.fixture
-def mock_task_instance(mock_marc_as_json, monkeypatch):
-    def mock_xcom_pull(*args, **kwargs):
-        key = kwargs.get("key")
-        task_ids = kwargs.get("task_ids")
-        if key == "resources":
-            return [
-                "http://example.com/rdf/0000-1111-2222-3333",
-                "http://example.com/rdf/4444-5555-6666-7777",
-            ]
-        elif task_ids == ["process_symphony.marc_json_to_s3"]:
-            return mock_marc_as_json
-        else:
-            return mock_push_store[key]
-
-    def mock_xcom_push(*args, **kwargs):
-        key = kwargs.get("key")
-        value = kwargs.get("value")
-        mock_push_store[key] = value
-        return None
-
-    monkeypatch.setattr(TaskInstance, "xcom_pull", mock_xcom_pull)
-    monkeypatch.setattr(TaskInstance, "xcom_push", mock_xcom_push)
-
-
-def test_to_symphony_json(mock_task_instance):
+def test_to_symphony_json(mock_task_instance):  # noqa: F811
     to_symphony_json(task_instance=task_instance)
     symphony_json = task_instance.xcom_pull(
-        key="http://example.com/rdf/0000-1111-2222-3333"
+        key="https://api.development.sinopia.io/resource/0000-1111-2222-3333"
     )
     assert symphony_json["standard"].startswith("MARC21")
     assert symphony_json["leader"].startswith("01455nam a2200277uu 4500")

--- a/tests/tasks/symphony/test_mod_json.py
+++ b/tests/tasks/symphony/test_mod_json.py
@@ -1,5 +1,4 @@
 """Tests functions for modifying JSON to Symphony JSON."""
-import json
 import pytest
 from datetime import datetime
 
@@ -26,17 +25,20 @@ mock_push_store = {}
 
 @pytest.fixture
 def mock_marc_as_json():
-    with open('tests/fixtures/record.json') as data:
+    with open("tests/fixtures/record.json") as data:
         return data.read()
 
 
 @pytest.fixture
-def mock_task_instance(mock_marc_as_json,monkeypatch): # , mock_resources):
+def mock_task_instance(mock_marc_as_json, monkeypatch):
     def mock_xcom_pull(*args, **kwargs):
         key = kwargs.get("key")
         task_ids = kwargs.get("task_ids")
         if key == "resources":
-            return ["http://example.com/rdf/0000-1111-2222-3333", "http://example.com/rdf/4444-5555-6666-7777"]
+            return [
+                "http://example.com/rdf/0000-1111-2222-3333",
+                "http://example.com/rdf/4444-5555-6666-7777",
+            ]
         elif task_ids == ["process_symphony.marc_json_to_s3"]:
             return mock_marc_as_json
         else:
@@ -54,7 +56,9 @@ def mock_task_instance(mock_marc_as_json,monkeypatch): # , mock_resources):
 
 def test_to_symphony_json(mock_task_instance):
     to_symphony_json(task_instance=task_instance)
-    symphony_json = task_instance.xcom_pull(key="http://example.com/rdf/0000-1111-2222-3333")
+    symphony_json = task_instance.xcom_pull(
+        key="http://example.com/rdf/0000-1111-2222-3333"
+    )
     assert symphony_json["standard"].startswith("MARC21")
     assert symphony_json["leader"].startswith("01455nam a2200277uu 4500")
     assert symphony_json["fields"][0]["tag"] == "003"

--- a/tests/tasks/symphony/test_new.py
+++ b/tests/tasks/symphony/test_new.py
@@ -14,6 +14,7 @@ from pytest_mock import MockerFixture
 
 from ils_middleware.tasks.symphony.new import NewMARCtoSymphony
 
+
 def test_task():
     return DummyOperator(
         task_id="test_task",

--- a/tests/tasks/symphony/test_new.py
+++ b/tests/tasks/symphony/test_new.py
@@ -3,11 +3,57 @@
 
 import pytest
 import requests  # type: ignore
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators.dummy import DummyOperator
+from airflow.models.taskinstance import TaskInstance
 
 from airflow.hooks.base_hook import BaseHook
 from pytest_mock import MockerFixture
 
 from ils_middleware.tasks.symphony.new import NewMARCtoSymphony
+
+def test_task():
+    return DummyOperator(
+        task_id="test_task",
+        dag=DAG(
+            "test_dag",
+            default_args={"owner": "airflow", "start_date": datetime(2021, 9, 20)},
+        ),
+    )
+
+
+task_instance = TaskInstance(test_task())
+mock_push_store = {}
+
+
+@pytest.fixture
+def mock_marc_as_json():
+    with open('tests/fixtures/record.json') as data:
+        return data.read()
+
+
+@pytest.fixture
+def mock_task_instance(mock_marc_as_json, monkeypatch): # , mock_resources):
+    def mock_xcom_pull(*args, **kwargs):
+        key = kwargs.get("key")
+        task_ids = kwargs.get("task_ids")
+        if key == "new_resources":
+            return ["http://example.com/rdf/0000-1111-2222-3333", "http://example.com/rdf/4444-5555-6666-7777"]
+        elif task_ids == ["process_symphony.convert_to_symphony_json"]:
+            return mock_marc_as_json
+        else:
+            return mock_push_store[key]
+
+    def mock_xcom_push(*args, **kwargs):
+        key = kwargs.get("key")
+        value = kwargs.get("value")
+        mock_push_store[key] = value
+        return None
+
+    monkeypatch.setattr(TaskInstance, "xcom_pull", mock_xcom_pull)
+    monkeypatch.setattr(TaskInstance, "xcom_push", mock_xcom_push)
 
 
 @pytest.fixture
@@ -34,15 +80,16 @@ def mock_new_request(monkeypatch, mocker: MockerFixture):
     monkeypatch.setattr(requests, "post", mock_post)
 
 
-def test_NewMARCtoSymphony(mock_connection, mock_new_request):
+def test_NewMARCtoSymphony(mock_connection, mock_new_request, mock_task_instance):
     """Tests NewMARCtoSymphony"""
-    task_result = NewMARCtoSymphony(
+    NewMARCtoSymphony(
+        task_instance=task_instance,
         conn_id="symphony_dev_login",
         session_token="abcde4590",
         library_key="GREEN",
         marc_json="""{"leader": "11222999   adf", "fields": [{"tag": "245"}]}""",
     )
-    assert "45678" == task_result
+    assert task_instance.xcom_pull(key="http://example.com/rdf/0000-1111-2222-3333") == "45678"
 
 
 @pytest.fixture
@@ -56,12 +103,13 @@ def mock_failed_request(monkeypatch, mocker: MockerFixture):
     monkeypatch.setattr(requests, "post", mock_failed_post)
 
 
-def test_NewMARCtoSymphony_failed(mock_connection, mock_failed_request):
-    """Test failed NewMARCtoSymphony"""
-    with pytest.raises(Exception, match="Symphony Web Service"):
-        NewMARCtoSymphony(
-            conn_id="symphony_dev_login",
-            session_token="abcde3456",
-            library_key="GREEN",
-            marc_json="""{"leader": "11222999   adf", "fields": [{"tag": "245"}]}""",
-        )
+# def test_NewMARCtoSymphony_failed(mock_connection, mock_failed_request, mock_task_instance):
+#     """Test failed NewMARCtoSymphony"""
+#     with pytest.raises(Exception, match="Symphony Web Service"):
+#         NewMARCtoSymphony(
+#             task_instance=task_instance,
+#             conn_id="symphony_dev_login",
+#             session_token="abcde3456",
+#             library_key="GREEN",
+#             marc_json="""{"leader": "11222999   adf", "fields": [{"tag": "245"}]}""",
+#         )

--- a/tests/tasks/symphony/test_new.py
+++ b/tests/tasks/symphony/test_new.py
@@ -3,61 +3,15 @@
 
 import pytest
 import requests  # type: ignore
-from datetime import datetime
-
-from airflow import DAG
-from airflow.operators.dummy import DummyOperator
-from airflow.models.taskinstance import TaskInstance
 
 from airflow.hooks.base_hook import BaseHook
 from pytest_mock import MockerFixture
 
 from ils_middleware.tasks.symphony.new import NewMARCtoSymphony
 
+from tasks import test_task_instance, mock_task_instance  # noqa: F401
 
-def test_task():
-    return DummyOperator(
-        task_id="test_task",
-        dag=DAG(
-            "test_dag",
-            default_args={"owner": "airflow", "start_date": datetime(2021, 9, 20)},
-        ),
-    )
-
-
-task_instance = TaskInstance(test_task())
-mock_push_store = {}
-
-
-@pytest.fixture
-def mock_marc_as_json():
-    with open("tests/fixtures/record.json") as data:
-        return data.read()
-
-
-@pytest.fixture
-def mock_task_instance(mock_marc_as_json, monkeypatch):
-    def mock_xcom_pull(*args, **kwargs):
-        key = kwargs.get("key")
-        task_ids = kwargs.get("task_ids")
-        if key == "new_resources":
-            return [
-                "http://example.com/rdf/0000-1111-2222-3333",
-                "http://example.com/rdf/4444-5555-6666-7777",
-            ]
-        elif task_ids == ["process_symphony.convert_to_symphony_json"]:
-            return mock_marc_as_json
-        else:
-            return mock_push_store[key]
-
-    def mock_xcom_push(*args, **kwargs):
-        key = kwargs.get("key")
-        value = kwargs.get("value")
-        mock_push_store[key] = value
-        return None
-
-    monkeypatch.setattr(TaskInstance, "xcom_pull", mock_xcom_pull)
-    monkeypatch.setattr(TaskInstance, "xcom_push", mock_xcom_push)
+task_instance = test_task_instance()
 
 
 @pytest.fixture
@@ -84,7 +38,9 @@ def mock_new_request(monkeypatch, mocker: MockerFixture):
     monkeypatch.setattr(requests, "post", mock_post)
 
 
-def test_NewMARCtoSymphony(mock_connection, mock_new_request, mock_task_instance):
+def test_NewMARCtoSymphony(
+    mock_connection, mock_new_request, mock_task_instance  # noqa: F811
+):  # noqa: F811
     """Tests NewMARCtoSymphony"""
     NewMARCtoSymphony(
         task_instance=task_instance,
@@ -94,7 +50,9 @@ def test_NewMARCtoSymphony(mock_connection, mock_new_request, mock_task_instance
         marc_json="""{"leader": "11222999   adf", "fields": [{"tag": "245"}]}""",
     )
     assert (
-        task_instance.xcom_pull(key="http://example.com/rdf/0000-1111-2222-3333")
+        task_instance.xcom_pull(
+            key="https://api.development.sinopia.io/resource/0000-1111-2222-3333"
+        )
         == "45678"
     )
 
@@ -108,15 +66,3 @@ def mock_failed_request(monkeypatch, mocker: MockerFixture):
         return failed_result
 
     monkeypatch.setattr(requests, "post", mock_failed_post)
-
-
-# def test_NewMARCtoSymphony_failed(mock_connection, mock_failed_request, mock_task_instance):
-#     """Test failed NewMARCtoSymphony"""
-#     with pytest.raises(Exception, match="Symphony Web Service"):
-#         NewMARCtoSymphony(
-#             task_instance=task_instance,
-#             conn_id="symphony_dev_login",
-#             session_token="abcde3456",
-#             library_key="GREEN",
-#             marc_json="""{"leader": "11222999   adf", "fields": [{"tag": "245"}]}""",
-#         )

--- a/tests/tasks/symphony/test_new.py
+++ b/tests/tasks/symphony/test_new.py
@@ -31,17 +31,20 @@ mock_push_store = {}
 
 @pytest.fixture
 def mock_marc_as_json():
-    with open('tests/fixtures/record.json') as data:
+    with open("tests/fixtures/record.json") as data:
         return data.read()
 
 
 @pytest.fixture
-def mock_task_instance(mock_marc_as_json, monkeypatch): # , mock_resources):
+def mock_task_instance(mock_marc_as_json, monkeypatch):
     def mock_xcom_pull(*args, **kwargs):
         key = kwargs.get("key")
         task_ids = kwargs.get("task_ids")
         if key == "new_resources":
-            return ["http://example.com/rdf/0000-1111-2222-3333", "http://example.com/rdf/4444-5555-6666-7777"]
+            return [
+                "http://example.com/rdf/0000-1111-2222-3333",
+                "http://example.com/rdf/4444-5555-6666-7777",
+            ]
         elif task_ids == ["process_symphony.convert_to_symphony_json"]:
             return mock_marc_as_json
         else:
@@ -90,7 +93,10 @@ def test_NewMARCtoSymphony(mock_connection, mock_new_request, mock_task_instance
         library_key="GREEN",
         marc_json="""{"leader": "11222999   adf", "fields": [{"tag": "245"}]}""",
     )
-    assert task_instance.xcom_pull(key="http://example.com/rdf/0000-1111-2222-3333") == "45678"
+    assert (
+        task_instance.xcom_pull(key="http://example.com/rdf/0000-1111-2222-3333")
+        == "45678"
+    )
 
 
 @pytest.fixture

--- a/tests/tasks/symphony/test_overlay.py
+++ b/tests/tasks/symphony/test_overlay.py
@@ -1,14 +1,49 @@
 import pytest
-
 import requests  # type: ignore
+from datetime import datetime
+
+from airflow import DAG
+from airflow.operators.dummy import DummyOperator
+from airflow.models.taskinstance import TaskInstance
 
 from airflow.hooks.base_hook import BaseHook
 from pytest_mock import MockerFixture
 
 from ils_middleware.tasks.symphony.overlay import overlay_marc_in_symphony
 
-MARC_JSON = """{"leader": "11222999   adf", "fields": [{"tag": "245"}]}"""
 CATKEY = "320011"
+MARC_JSON = {"leader": "11222999   adf", "fields": [{"tag": "245"}], "catkey": CATKEY}
+MARC_JSON_NO_CAT_KEY = {"leader": "11222999   adf", "fields": [{"tag": "245"}]}
+
+def test_task():
+    return DummyOperator(
+        task_id="test_task",
+        dag=DAG(
+            "test_dag",
+            default_args={"owner": "airflow", "start_date": datetime(2021, 9, 20)},
+        ),
+    )
+
+
+@pytest.fixture
+def mock_marc_as_json():
+    with open('tests/fixtures/record.json') as data:
+        return data.read()
+
+
+task_instance = TaskInstance(test_task())
+mock_push_store = {
+    "overlay_resources": [
+        {
+            "resource_uri": "http://example.com/rdf/0000-1111-2222-3333",
+            "data": MARC_JSON
+        },
+        {
+            "resource_uri": "http://example.com/rdf/4444-5555-6666-7777",
+            "data": MARC_JSON_NO_CAT_KEY
+        }
+    ]
+}
 
 
 @pytest.fixture
@@ -35,20 +70,41 @@ def mock_new_request(monkeypatch, mocker: MockerFixture):
     monkeypatch.setattr(requests, "put", mock_put)
 
 
-def test_overlay_marc_in_symphony(mock_new_request, mock_connection):
-    task_result = overlay_marc_in_symphony(
+@pytest.fixture
+def mock_task_instance(mock_marc_as_json, monkeypatch): # , mock_resources):
+    def mock_xcom_pull(*args, **kwargs):
+        key = kwargs.get("key")
+        task_ids = kwargs.get("task_ids")
+        if task_ids == ["process_symphony.convert_to_symphony_json"]:
+            return mock_marc_as_json
+        else:
+            return mock_push_store[key]
+
+    def mock_xcom_push(*args, **kwargs):
+        key = kwargs.get("key")
+        value = kwargs.get("value")
+        mock_push_store[key] = value
+        return None
+
+    monkeypatch.setattr(TaskInstance, "xcom_pull", mock_xcom_pull)
+    monkeypatch.setattr(TaskInstance, "xcom_push", mock_xcom_push)
+
+
+def test_overlay_marc_in_symphony(mock_new_request, mock_connection, mock_task_instance):
+    overlay_marc_in_symphony(
+        task_instance=task_instance,
         conn_id="symphony_dev_login",
         session_token="abcde4590",
         catkey=CATKEY,
         marc_json=MARC_JSON,
     )
+    assert task_instance.xcom_pull(key='http://example.com/rdf/0000-1111-2222-3333').startswith(CATKEY)
 
-    assert task_result.startswith(CATKEY)
 
-
-def test_missing_catkey(mock_new_request, mock_connection):
-
-    with pytest.raises(ValueError, match="Catalog ID is required"):
-        overlay_marc_in_symphony(
-            conn_id="symphony_dev_login", session_token="abcde4590", marc_json=MARC_JSON
-        )
+def test_missing_catkey(mock_new_request, mock_connection, mock_task_instance):
+    overlay_marc_in_symphony(
+        task_instance=task_instance,
+        conn_id="symphony_dev_login",
+        session_token="abcde4590",
+    )
+    assert len(task_instance.xcom_pull(key="missing_catkeys")) > 0

--- a/tests/tasks/symphony/test_overlay.py
+++ b/tests/tasks/symphony/test_overlay.py
@@ -15,6 +15,7 @@ CATKEY = "320011"
 MARC_JSON = {"leader": "11222999   adf", "fields": [{"tag": "245"}], "catkey": CATKEY}
 MARC_JSON_NO_CAT_KEY = {"leader": "11222999   adf", "fields": [{"tag": "245"}]}
 
+
 def test_task():
     return DummyOperator(
         task_id="test_task",
@@ -27,7 +28,7 @@ def test_task():
 
 @pytest.fixture
 def mock_marc_as_json():
-    with open('tests/fixtures/record.json') as data:
+    with open("tests/fixtures/record.json") as data:
         return data.read()
 
 
@@ -36,12 +37,12 @@ mock_push_store = {
     "overlay_resources": [
         {
             "resource_uri": "http://example.com/rdf/0000-1111-2222-3333",
-            "data": MARC_JSON
+            "data": MARC_JSON,
         },
         {
             "resource_uri": "http://example.com/rdf/4444-5555-6666-7777",
-            "data": MARC_JSON_NO_CAT_KEY
-        }
+            "data": MARC_JSON_NO_CAT_KEY,
+        },
     ]
 }
 
@@ -71,7 +72,7 @@ def mock_new_request(monkeypatch, mocker: MockerFixture):
 
 
 @pytest.fixture
-def mock_task_instance(mock_marc_as_json, monkeypatch): # , mock_resources):
+def mock_task_instance(mock_marc_as_json, monkeypatch):
     def mock_xcom_pull(*args, **kwargs):
         key = kwargs.get("key")
         task_ids = kwargs.get("task_ids")
@@ -90,7 +91,9 @@ def mock_task_instance(mock_marc_as_json, monkeypatch): # , mock_resources):
     monkeypatch.setattr(TaskInstance, "xcom_push", mock_xcom_push)
 
 
-def test_overlay_marc_in_symphony(mock_new_request, mock_connection, mock_task_instance):
+def test_overlay_marc_in_symphony(
+    mock_new_request, mock_connection, mock_task_instance
+):
     overlay_marc_in_symphony(
         task_instance=task_instance,
         conn_id="symphony_dev_login",
@@ -98,7 +101,9 @@ def test_overlay_marc_in_symphony(mock_new_request, mock_connection, mock_task_i
         catkey=CATKEY,
         marc_json=MARC_JSON,
     )
-    assert task_instance.xcom_pull(key='http://example.com/rdf/0000-1111-2222-3333').startswith(CATKEY)
+    assert task_instance.xcom_pull(
+        key="http://example.com/rdf/0000-1111-2222-3333"
+    ).startswith(CATKEY)
 
 
 def test_missing_catkey(mock_new_request, mock_connection, mock_task_instance):

--- a/tests/tasks/symphony/test_overlay.py
+++ b/tests/tasks/symphony/test_overlay.py
@@ -1,50 +1,18 @@
 import pytest
 import requests  # type: ignore
-from datetime import datetime
-
-from airflow import DAG
-from airflow.operators.dummy import DummyOperator
-from airflow.models.taskinstance import TaskInstance
 
 from airflow.hooks.base_hook import BaseHook
 from pytest_mock import MockerFixture
 
 from ils_middleware.tasks.symphony.overlay import overlay_marc_in_symphony
 
+from tasks import test_task_instance, mock_task_instance  # noqa: F401
+
+task_instance = test_task_instance()
+
 CATKEY = "320011"
 MARC_JSON = {"leader": "11222999   adf", "fields": [{"tag": "245"}], "catkey": CATKEY}
 MARC_JSON_NO_CAT_KEY = {"leader": "11222999   adf", "fields": [{"tag": "245"}]}
-
-
-def test_task():
-    return DummyOperator(
-        task_id="test_task",
-        dag=DAG(
-            "test_dag",
-            default_args={"owner": "airflow", "start_date": datetime(2021, 9, 20)},
-        ),
-    )
-
-
-@pytest.fixture
-def mock_marc_as_json():
-    with open("tests/fixtures/record.json") as data:
-        return data.read()
-
-
-task_instance = TaskInstance(test_task())
-mock_push_store = {
-    "overlay_resources": [
-        {
-            "resource_uri": "http://example.com/rdf/0000-1111-2222-3333",
-            "data": MARC_JSON,
-        },
-        {
-            "resource_uri": "http://example.com/rdf/4444-5555-6666-7777",
-            "data": MARC_JSON_NO_CAT_KEY,
-        },
-    ]
-}
 
 
 @pytest.fixture
@@ -71,28 +39,8 @@ def mock_new_request(monkeypatch, mocker: MockerFixture):
     monkeypatch.setattr(requests, "put", mock_put)
 
 
-@pytest.fixture
-def mock_task_instance(mock_marc_as_json, monkeypatch):
-    def mock_xcom_pull(*args, **kwargs):
-        key = kwargs.get("key")
-        task_ids = kwargs.get("task_ids")
-        if task_ids == ["process_symphony.convert_to_symphony_json"]:
-            return mock_marc_as_json
-        else:
-            return mock_push_store[key]
-
-    def mock_xcom_push(*args, **kwargs):
-        key = kwargs.get("key")
-        value = kwargs.get("value")
-        mock_push_store[key] = value
-        return None
-
-    monkeypatch.setattr(TaskInstance, "xcom_pull", mock_xcom_pull)
-    monkeypatch.setattr(TaskInstance, "xcom_push", mock_xcom_push)
-
-
 def test_overlay_marc_in_symphony(
-    mock_new_request, mock_connection, mock_task_instance
+    mock_new_request, mock_connection, mock_task_instance  # noqa: F811
 ):
     overlay_marc_in_symphony(
         task_instance=task_instance,
@@ -102,11 +50,13 @@ def test_overlay_marc_in_symphony(
         marc_json=MARC_JSON,
     )
     assert task_instance.xcom_pull(
-        key="http://example.com/rdf/0000-1111-2222-3333"
+        key="https://api.development.sinopia.io/resource/0000-1111-2222-3333"
     ).startswith(CATKEY)
 
 
-def test_missing_catkey(mock_new_request, mock_connection, mock_task_instance):
+def test_missing_catkey(
+    mock_new_request, mock_connection, mock_task_instance  # noqa: F811
+):  # noqa: F811
     overlay_marc_in_symphony(
         task_instance=task_instance,
         conn_id="symphony_dev_login",


### PR DESCRIPTION
Fixes #70 

This is a fairly simple but extensive refactoring to allow the processing of multiple SQS messages. The most significant concerns is no longer raising errors and failing tasks but instead pushing data into xcom for failures for later reporting.

This should not be merged until reviewed and discussed with @jermnelson / @jmartin-sul and manually tested.