### PR TITLE
stanford DAG failure callbacks: send honeybadger notification

### DIFF
--- a/ils_middleware/tasks/sinopia/email.py
+++ b/ils_middleware/tasks/sinopia/email.py
@@ -25,10 +25,8 @@ def send_update_success_emails(**kwargs) -> None:
 
 def send_task_failure_notifications(**kwargs) -> None:
     parent_task_ids = list(kwargs["task"].upstream_task_ids)
-
     err_msg_context = {"parent_task_ids": parent_task_ids, "kwargs": kwargs}
-    honeybadger.notify("Error executing upstream task", context=err_msg_context)
-    logger.error(f"Error executing upstream task: err_msg_context={err_msg_context}")
+    notify_and_log("Error executing upstream task", err_msg_context)
 
     task_instance = kwargs["task_instance"]
     user_email = task_instance.xcom_pull(key="email", task_ids=["sqs-message-parse"])
@@ -39,6 +37,11 @@ def send_task_failure_notifications(**kwargs) -> None:
             "Unable to determine user to notify for task failure",
             context=err_msg_context,
         )
+
+
+def notify_and_log(err_msg: str, err_msg_context: dict) -> None:
+    honeybadger.notify(err_msg, context=err_msg_context)
+    logger.error(f"{err_msg}: err_msg_context={err_msg_context}")
 
 
 def _send_task_failure_email(


### PR DESCRIPTION
refactor `honeybadger.notify()`/`logger.error()` combo into small helper method, provide lightly wrapped helper as failure callback for stanford DAG and default failure callback for tasks in stanford DAG.

i noticed that the callback wasn't firing in all the cases where i expected it to, e.g. when i marked a task that was up for retry as failed (which then triggered a downstream task with `trigger_rule="one_failed"`).  it turns out this might explain the unexpected/inconsistent behavior (found in the [airflow docs](https://airflow.apache.org/docs/apache-airflow/2.2.1/logging-monitoring/callbacks.html) when trying to figure this out yesterday evening):

"Callback functions are only invoked when the task state changes due to execution by a worker. As such, task changes set by the command line interface (CLI) or user interface (UI) do not execute callback functions."

i also had some trouble figuring out how to write DAG level unit tests for this newly added hook, without running into the same DB init issues i ran into trying to write DAG level tests for #84.

i did get some unexpected testing for free when shutting down my local docker stack:  the failure hooks ran when the workers were terminated.


https://app.honeybadger.io/projects/92887/faults/82601964
https://app.honeybadger.io/projects/92887/faults/82602234

closes #85