### PR TITLE
Fixes Key Error in SQS Message Parse

### DIFF
--- a/ils_middleware/tasks/amazon/sqs.py
+++ b/ils_middleware/tasks/amazon/sqs.py
@@ -40,7 +40,6 @@ def parse_messages(**kwargs) -> str:
 
     resources = []
     for message in raw_sqs_messages:
-        message = message[0]
         message_body = json.loads(message.get("Body"))
         resource_uri = message_body["resource"]["uri"]
         resources.append(resource_uri)

--- a/tests/helpers/tasks.py
+++ b/tests/helpers/tasks.py
@@ -88,18 +88,14 @@ mock_push_store: dict = {}
 
 def mock_message():
     return [
-        [
-            {
-                "Body": """{ "user": { "email": "dscully@stanford.edu"},
-                            "resource": { "uri": "https://api.development.sinopia.io/resource/0000-1111-2222-3333" }}"""
-            }
-        ],
-        [
-            {
-                "Body": """{ "user": { "email": "fmulder@stanford.edu"},
-                            "resource": { "uri": "https://api.development.sinopia.io/resource/4444-5555-6666-7777" }}"""
-            }
-        ],
+        {
+            "Body": """{ "user": { "email": "dscully@stanford.edu"},
+                        "resource": { "uri": "https://api.development.sinopia.io/resource/0000-1111-2222-3333" }}"""
+        },
+        {
+            "Body": """{ "user": { "email": "fmulder@stanford.edu"},
+                        "resource": { "uri": "https://api.development.sinopia.io/resource/4444-5555-6666-7777" }}"""
+        },
     ]
 
 


### PR DESCRIPTION
Fixes the following error in `tasks/amazon/sqs.py`

```  
File "/home/airflow/.local/lib/python3.9/site-packages/ils_middleware/tasks/amazon/sqs.py", line 43, in parse_messages
    message = message[0]
KeyError: 0```