### PR TITLE
Use Airflow Variables for rdf2marc Lambda

### DIFF
--- a/ils_middleware/dags/stanford.py
+++ b/ils_middleware/dags/stanford.py
@@ -72,8 +72,8 @@ with DAG(
             task_id="rdf2marc",
             python_callable=Rdf2Marc,
             op_kwargs={
-                "rdf2marc_lambda": "sinopia-rdf2marc-development",
-                "s3_bucket": "sinopia-marc-development",
+                "rdf2marc_lambda": Variable.get("rdf2marc_lambda"),
+                "s3_bucket": Variable.get("marc_s3_bucket"),
             },
         )
 


### PR DESCRIPTION
Originally set correctly in @jmartin-sul PR [95](https://github.com/LD4P/ils-middleware/pull/95/files#diff-0b48c47f36142f23b65d0ecefe364cc19edee46e54b336ddc12d3f36b97e2bd6R65-R66), subsequent PR reverted to using old `op_kwargs` defaults, restores to use in staging environment.