### PR TITLE
Revert to use Airflow vars for S3 buckets names

### DIFF
--- a/ils_middleware/tasks/amazon/s3.py
+++ b/ils_middleware/tasks/amazon/s3.py
@@ -2,6 +2,8 @@ import logging
 from urllib.parse import urlparse
 import os
 from os import path
+
+from airflow.models import Variable
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from pymarc import MARCReader
 
@@ -19,7 +21,7 @@ def get_from_s3(**kwargs):
 
         temp_file = s3_hook.download_file(
             key=f"marc/airflow/{instance_id}/record.mar",
-            bucket_name="sinopia-marc-development",
+            bucket_name=Variable.get("marc_s3_bucket"),
         )
         task_instance.xcom_push(key=instance_uri, value=temp_file)
 
@@ -39,7 +41,7 @@ def send_to_s3(**kwargs):
         s3_hook.load_string(
             marc_record.as_json(),
             f"marc/airflow/{instance_id}/record.json",
-            "sinopia-marc-development",
+            Variable.get("marc_s3_bucket"),
             replace=True,
         )
         task_instance.xcom_push(key=instance_uri, value=marc_record.as_json())

--- a/tests/tasks/amazon/test_s3.py
+++ b/tests/tasks/amazon/test_s3.py
@@ -31,7 +31,7 @@ def mock_s3_load_string():
         yield mocked
 
 
-def test_get_from_s3(mock_s3_hook, mock_task_instance):
+def test_get_from_s3(mock_env_vars, mock_s3_hook, mock_task_instance):
     """Test downloading a file from S3 into a temp file"""
     get_from_s3(task_instance=test_task_instance())
     assert (
@@ -48,7 +48,7 @@ def test_get_from_s3(mock_s3_hook, mock_task_instance):
     )
 
 
-def test_send_to_s3(mock_s3_load_string, mock_task_instance):
+def test_send_to_s3(mock_env_vars, mock_s3_load_string, mock_task_instance):
     """Test sending a file to s3"""
 
     send_to_s3(task_instance=test_task_instance())


### PR DESCRIPTION
Continuing to fix bad rebase errors, now use correct Airflow Variables for `marc_s3_bucket` in S3 task functions. 