### PR TITLE
Add localstack and instructions for use

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,39 @@ Based on the documentation, [Running Airflow in Docker](https://airflow.apache.o
    add `docker compose up -d` to run as a daemon.
 1. Access Airflow locally at http://localhost:8080
 
+### Setup the SQS queue in localstack for local development
+
+```
+AWS_ACCESS_KEY_ID=999999 AWS_SECRET_ACCESS_KEY=1231 aws sqs \
+    --endpoint-url=http://localhost:4566 create-queue \
+    --region us-west-2 \
+    --queue-name stanford-ils
+```
+
+### Setup the local AWS connection for SQS
+
+1. From the `Admin > Connectinos` menu
+2. Click the "+"
+3. Add an Amazon Web Services connection with the following settings:
+     
+    * Connection Id: aws_sqs_connection
+    * Login: 999999
+    * Password: 1231
+    * Extra: `{"host": "http://localstack:4566", "region_name": "us-west-2"}`
+
+### Send a message to the SQS queue
+
+In order to test a dag locally, a message must be sent to the above queue:
+```
+AWS_ACCESS_KEY_ID=999999 AWS_SECRET_ACCESS_KEY=1231 aws sqs \
+    send-message \
+    --endpoint-url=http://localhost:4566 \
+    --queue-url https://localhost:4566/000000000000/stanford-ils \
+    --message-body file://tests/fixtures/sqs/test-message.json
+```
+
+Note: the test message content in `tests/fixtures/sqs/test-message.json` contains an email address that you can update to your own.
+
 ## Editing existing DAGs
 The `dags/stanford.py` contains Stanford's Symphony and FOLIO workflows from
 Sinopia editor user initiated process. The `dags/cornell.py` DAG is for Cornell's

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,8 +47,8 @@ x-airflow-common:
   # In order to add custom dependencies or upgrade provider packages you can use your extended image.
   # Comment the image line, place your Dockerfile in the directory where you placed the docker-compose.yaml
   # and uncomment the "build" line below, Then run `docker-compose build` to build the images.
-  image: ${AIRFLOW_IMAGE_NAME:-ld4p/ils-middleware:latest}
-  # build: .
+  # image: ${AIRFLOW_IMAGE_NAME:-ld4p/ils-middleware:latest}
+  build: .
   environment:
     &airflow-common-env
     AIRFLOW__CORE__EXECUTOR: CeleryExecutor
@@ -63,8 +63,14 @@ x-airflow-common:
     AIRFLOW_VAR_MARC_S3_BUCKET: 'sinopia-marc-development'
     AIRFLOW_VAR_RDF2MARC_LAMBDA: 'sinopia-rdf2marc-development'
     AIRFLOW_VAR_SINOPIA_ENV: ${AIRFLOW_VAR_SINOPIA_ENV:-dev}
-    AIRFLOW_VAR_SQS_URL: 'https://sqs.us-west-2.amazonaws.com/418214828013/stanford-ils'
+    AIRFLOW_VAR_SQS_URL: 'http://localstack:4566/000000000000/'
     AIRFLOW_VAR_SYMPHONY_APP_ID: 'SINOPIA_DEV'
+    AIRFLOW_VAR_STANFORD_SYMPHONY_LOGIN: 'USERNAME'
+    AIRFLOW_VAR_STANFORD_SYMPHONY_PASSWORD: 'PASSWORD'
+    AIRFLOW_VAR_STANFORD_SYMPHONY_AUTH_URL: 'https://okapi-folio.dev.sul.stanford.edu/authn/login'
+    AIRFLOW_VAR_STANFORD_FOLIO_LOGIN: 'USERNAME'
+    AIRFLOW_VAR_STANFORD_FOLIO_PASSWORD: 'PASSWORD'
+    AIRFLOW_VAR_STANFORD_FOLIO_AUTH_URL: 'https://okapi-folio.dev.sul.stanford.edu/authn/login'
     HONEYBADGER_API_KEY: ${HONEYBADGER_API_KEY:-}
     LOGLEVEL: ${LOGLEVEL:-DEBUG}
     _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
@@ -175,6 +181,16 @@ services:
       timeout: 10s
       retries: 5
     restart: always
+
+  localstack:
+    image: localstack/localstack
+    ports:
+      - "4566:4566"
+    environment:
+      - SERVICES=sqs
+      - AWS_DEFAULT_REGION=us-west-2
+      - DOCKER_HOST=unix:///var/run/docker.sock
+      - DEBUG=1
 
 volumes:
   postgres-db-volume:

--- a/ils_middleware/dags/stanford.py
+++ b/ils_middleware/dags/stanford.py
@@ -108,6 +108,7 @@ with DAG(
                 "app_id": symphony_app_id,
                 "client_id": symphony_client_id,
                 "conn_id": symphony_conn_id,
+                "url": Variable.get("stanford_symphony_auth_url"),
                 "login": Variable.get("stanford_symphony_login"),
                 "password": Variable.get("stanford_symphony_password"),
             },

--- a/tests/fixtures/sqs/test-message.json
+++ b/tests/fixtures/sqs/test-message.json
@@ -1,0 +1,10 @@
+{
+  "resource": {
+    "uri":"https://api.development.sinopia.io/resource/61de0374-5fab-4a5d-8d92-2d43f006d4d3"
+  },
+  "user": {
+    "email":"amcollie@stanford.edu"
+  },
+  "group": "stanford",
+  "target": "ils"
+}


### PR DESCRIPTION
This adds SQS through localstack for local development and testing to avoid conflicts with the dev/stage environments - especially once metadata starts heavily tesitng.

There are also a couple of minor bug fixes adding env variables to docker-compose.