### PR TITLE
Set the SQS sensor to timeout after 4 minutes

### DIFF
--- a/ils_middleware/tasks/amazon/sqs.py
+++ b/ils_middleware/tasks/amazon/sqs.py
@@ -22,6 +22,7 @@ def SubscribeOperator(**kwargs) -> SQSSensor:
         task_id="sqs-sensor",
         dag=kwargs.get("dag"),
         max_messages=10,
+        timeout=240,
     )
 
 


### PR DESCRIPTION
This adds a 4 minute timeout to the SQS sensor. The entire DAG has a 5 minute reschedule timer, so without this timeout we end up with an excessive number of tasks. With a shorter timeout than the run schedule, we will greatly limit the number of concurrent tasks.
