### PR TITLE
Inject kwargs into email tasks so task and task_instance are available

### DIFF
--- a/ils_middleware/tasks/sinopia/email.py
+++ b/ils_middleware/tasks/sinopia/email.py
@@ -10,13 +10,11 @@ logger = logging.getLogger(__name__)
 
 
 def send_notification_emails(**kwargs) -> None:
-    task_instance = kwargs["task_instance"]
-
     # Send success emails first
-    send_update_success_emails(task_instance=task_instance)
+    send_update_success_emails(kwargs=kwargs)
 
     # send failure notifications
-    send_task_failure_notifications(task_instance=task_instance)
+    send_task_failure_notifications(kwargs=kwargs)
 
 
 def send_update_success_emails(**kwargs) -> None:


### PR DESCRIPTION
Fixes #145 

This replaces the extraction of task_instance from the kwargs for injection into the email methods in favor of all kwargs for the task.