### PR TITLE
Pass Kwargs as a parameter dictionary

### DIFF
--- a/ils_middleware/tasks/sinopia/email.py
+++ b/ils_middleware/tasks/sinopia/email.py
@@ -11,10 +11,10 @@ logger = logging.getLogger(__name__)
 
 def send_notification_emails(**kwargs) -> None:
     # Send success emails first
-    send_update_success_emails(kwargs=kwargs)
+    send_update_success_emails(**kwargs)
 
     # send failure notifications
-    send_task_failure_notifications(kwargs=kwargs)
+    send_task_failure_notifications(**kwargs)
 
 
 def send_update_success_emails(**kwargs) -> None:


### PR DESCRIPTION
Python peculiarity for passing kwargs from one function to another. 

Fixes this bug on dev:
```python
  File "/home/airflow/.local/lib/python3.9/site-packages/airflow/task/task_runner/standard_task_runner.py", line 85, in _start_by_fork
    args.func(args, dag=self.dag)
  File "/home/airflow/.local/lib/python3.9/site-packages/airflow/cli/cli_parser.py", line 48, in command
    return func(*args, **kwargs)
  File "/home/airflow/.local/lib/python3.9/site-packages/airflow/utils/cli.py", line 92, in wrapper
    return f(*args, **kwargs)
  File "/home/airflow/.local/lib/python3.9/site-packages/airflow/cli/commands/task_command.py", line 292, in task_run
    _run_task_by_selected_method(args, dag, ti)
  File "/home/airflow/.local/lib/python3.9/site-packages/airflow/cli/commands/task_command.py", line 107, in _run_task_by_selected_method
    _run_raw_task(args, ti)
  File "/home/airflow/.local/lib/python3.9/site-packages/airflow/cli/commands/task_command.py", line 180, in _run_raw_task
    ti._run_raw_task(
  File "/home/airflow/.local/lib/python3.9/site-packages/airflow/utils/session.py", line 70, in wrapper
    return func(*args, session=session, **kwargs)
  File "/home/airflow/.local/lib/python3.9/site-packages/airflow/models/taskinstance.py", line 1332, in _run_raw_task
    self._execute_task_with_callbacks(context)
  File "/home/airflow/.local/lib/python3.9/site-packages/airflow/models/taskinstance.py", line 1458, in _execute_task_with_callbacks
    result = self._execute_task(context, self.task)
  File "/home/airflow/.local/lib/python3.9/site-packages/airflow/models/taskinstance.py", line 1514, in _execute_task
    result = execute_callable(context=context)
  File "/home/airflow/.local/lib/python3.9/site-packages/airflow/operators/python.py", line 151, in execute
    return_value = self.execute_callable()
  File "/home/airflow/.local/lib/python3.9/site-packages/airflow/operators/python.py", line 162, in execute_callable
    return self.python_callable(*self.op_args, **self.op_kwargs)
  File "/home/airflow/.local/lib/python3.9/site-packages/ils_middleware/tasks/sinopia/email.py", line 14, in send_notification_emails
    send_update_success_emails(kwargs=kwargs)
  File "/home/airflow/.local/lib/python3.9/site-packages/ils_middleware/tasks/sinopia/email.py", line 21, in send_update_success_emails
    task_instance = kwargs["task_instance"]
KeyError: 'task_instance'
```