### PR TITLE
Use task-groups to construct correct task-id

### DIFF
--- a/ils_middleware/dags/stanford.py
+++ b/ils_middleware/dags/stanford.py
@@ -174,7 +174,10 @@ with DAG(
                 bf_to_folio = PythonOperator(
                     task_id=f"{folio_field}_task",
                     python_callable=map_to_folio,
-                    op_kwargs={"folio_field": folio_field},
+                    op_kwargs={
+                        "folio_field": folio_field,
+                        "task_groups_ids": ["process_folio"],
+                    },
                 )
 
         folio_login >> bf_graphs >> folio_map_task_group

--- a/tests/tasks/folio/test_map.py
+++ b/tests/tasks/folio/test_map.py
@@ -49,6 +49,7 @@ def test_folio(mock_task_instance, test_graph: rdflib.Graph):  # noqa: F811
     map_to_folio(
         task_instance=test_task_instance(),
         folio_field="title",
+        task_groups_ids=[""],
     )
 
     title_list = test_task_instance().xcom_pull(key=instance_uri)
@@ -65,6 +66,7 @@ def test_folio_work(mock_task_instance, test_graph: rdflib.Graph):  # noqa: F811
     map_to_folio(
         task_instance=test_task_instance(),
         folio_field="contributor.primary.Person",
+        task_groups_ids=[""],
     )
 
     contributors_list = test_task_instance().xcom_pull(key=instance_uri)


### PR DESCRIPTION
Fixes this error in Stage:

```python
ERROR - Task failed with exception
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.9/site-packages/airflow/models/taskinstance.py", line 1332, in _run_raw_task
    self._execute_task_with_callbacks(context)
  File "/home/airflow/.local/lib/python3.9/site-packages/airflow/models/taskinstance.py", line 1458, in _execute_task_with_callbacks
    result = self._execute_task(context, self.task)
  File "/home/airflow/.local/lib/python3.9/site-packages/airflow/models/taskinstance.py", line 1514, in _execute_task
    result = execute_callable(context=context)
  File "/home/airflow/.local/lib/python3.9/site-packages/airflow/operators/python.py", line 151, in execute
    return_value = self.execute_callable()
  File "/home/airflow/.local/lib/python3.9/site-packages/airflow/operators/python.py", line 162, in execute_callable
    return self.python_callable(*self.op_args, **self.op_kwargs)
  File "/home/airflow/.local/lib/python3.9/site-packages/ils_middleware/tasks/folio/map.py", line 103, in map_to_folio
    values = _build_and_query_graph(
  File "/home/airflow/.local/lib/python3.9/site-packages/ils_middleware/tasks/folio/map.py", line 86, in _build_and_query_graph
    json_ld = task_instance.xcom_pull(key=instance_uri, task_ids="bf-graph").get(
AttributeError: 'NoneType' object has no attribute 'get'
```