### PR TITLE
Lowercase value for content-type before FOLIO lookup

### DIFF
--- a/ils_middleware/tasks/folio/build.py
+++ b/ils_middleware/tasks/folio/build.py
@@ -103,8 +103,8 @@ def _instance_type_id(**kwargs) -> tuple:
     folio_client = kwargs["folio_client"]
     values = kwargs["values"]
 
-    # Only use first value
-    name = values[0][0]
+    # Only use first value and lowercase
+    name = values[0][0].lower()
 
     ident = None
 

--- a/tests/tasks/folio/test_build.py
+++ b/tests/tasks/folio/test_build.py
@@ -189,7 +189,7 @@ def test_instance_type_id(mock_requests_okapi):  # noqa: F811
         okapi_uri, "sul", "test_user", "asdfdsfa"
     )
     instance_type_id = _instance_type_id(
-        values=[["text"]], folio_client=folio_client_mock
+        values=[["Text"]], folio_client=folio_client_mock
     )
     assert instance_type_id[0].startswith("instanceTypeId")
     assert (instance_type_id[1]).startswith("6312d172-f0cf-40f6-b27d-9fa8feaf332f")


### PR DESCRIPTION
Allows catalogers to use capitalization for content-type in the Editor without causing an error when doing a FOLIO lookup.