### PR TITLE
Change HTTP error logging for FOLIO

### DIFF
--- a/ils_middleware/tasks/folio/new.py
+++ b/ils_middleware/tasks/folio/new.py
@@ -43,7 +43,7 @@ def _post_to_okapi(**kwargs):
     if new_record_result.status_code < 300:
         _push_to_xcom(records, task_instance)
     else:
-        logger.error(f"New records failed errors: {new_record_result.json()}")
+        logger.error(f"New records failed errors: {new_record_result.text}")
         new_record_result.raise_for_status()
 
 

--- a/tests/tasks/folio/test_new_inventory.py
+++ b/tests/tasks/folio/test_new_inventory.py
@@ -45,6 +45,7 @@ def mock_bad_request(monkeypatch, mocker: MockerFixture):
         post_response = mocker.stub(name="post_result")
         post_response.status_code = 422
         post_response.json = lambda: error_message
+        post_response.text = str(error_message)
         post_response.raise_for_status = mock_raise_for_status
         return post_response
 


### PR DESCRIPTION
Okapi (FOLIO API endpoint) HTTP error responses do not always return JSON messages. Change to use text method instead. We're seeing an issue trying to post new instances to our FOLIO test instance but the logging is raising a message trying to render the response as json, obscuring the underlying error.