### PR TITLE
DAG for Monitoring Single SQS Queue for all Groups

### DIFF
--- a/ils_middleware/dags/queue_monitor.py
+++ b/ils_middleware/dags/queue_monitor.py
@@ -1,0 +1,58 @@
+import json
+import logging
+
+from datetime import datetime, timedelta
+
+from airflow.decorators import dag, task
+from airflow.operators.trigger_dagrun import TriggerDagRunOperator
+
+from ils_middleware.dags.alma import institutions
+from ils_middleware.tasks.amazon.sqs import SubscribeOperator
+
+logger = logging.getLogger(__name__)
+
+
+@dag(
+    start_date=datetime(2024, 1, 15),
+    schedule_interval=timedelta(minutes=5),
+    catchup=False,
+)
+def monitor_institutions_messages():
+    """
+    ### Monitors SQS Queue and Triggers Institutional DAGs
+    """
+
+    listen_sqs = SubscribeOperator(queue="all-institutions")
+
+    @task
+    def parse_messages(**kwargs) -> list:
+        ti = kwargs["ti"]
+        messages = ti.xcom_pull(task_ids="sqs-sensor", key="messages")
+        institutional_messages = []
+        all_institutions = institutions + ["stanford", "cornell"]
+        for row in messages:
+            message = json.loads(row["Body"])
+            if message["group"] in all_institutions:
+                institutional_messages.append(message)
+        return institutional_messages
+
+    @task
+    def trigger_institutional_dags(**kwargs):
+        messages = kwargs.get("messages")
+        for message in messages:
+            logger.info(f"Trigger DAG for {message['group']}")
+            # Assumes the DAG name is the same as the group
+            TriggerDagRunOperator(
+                task_id=f"{message['group']}-dag-run",
+                trigger_dag_id=f"{message['group']}",
+                conf={"message": message},
+            ).execute(kwargs)
+
+    group_messages = parse_messages()
+
+    listen_sqs >> group_messages
+
+    trigger_institutional_dags(messages=group_messages)
+
+
+monitor_respond_messages = monitor_institutions_messages()

--- a/tests/dags/test_monitor_institutions_messages.py
+++ b/tests/dags/test_monitor_institutions_messages.py
@@ -1,0 +1,46 @@
+import json
+import pytest
+
+
+@pytest.fixture
+def mock_airflow_var(mocker):
+    mock_variable = mocker.patch(
+        "ils_middleware.tasks.amazon.sqs.Variable.get",
+        return_value="http://example.queue.edu/all-institutions",
+    )
+    return mock_variable
+
+
+messages = [
+    {"Body": json.dumps({"group": "stanford"})},
+    {"Body": json.dumps({"group": "colorado"})},
+]
+
+
+def test_parse_institutional_msgs(mock_airflow_var, mocker):
+    from ils_middleware.dags.queue_monitor import _parse_institutional_msgs
+
+    task_instance = mocker.MagicMock()
+    task_instance.xcom_pull = lambda **kwargs: messages
+    institutional_messages = _parse_institutional_msgs(task_instance)
+    assert len(institutional_messages) == 1
+    assert institutional_messages[0]["group"] == "stanford"
+
+
+def test_trigger_dags(mocker, mock_airflow_var, caplog):
+    mock_trigger_operator = mocker.patch(
+        "ils_middleware.dags.queue_monitor.TriggerDagRunOperator"
+    )
+    from ils_middleware.dags.queue_monitor import (
+        _parse_institutional_msgs,
+        _trigger_dags,
+    )
+
+    task_instance = mocker.MagicMock()
+    task_instance.xcom_pull = lambda **kwargs: messages
+
+    institutional_messages = _parse_institutional_msgs(task_instance)
+    _trigger_dags(messages=institutional_messages)
+
+    assert mock_trigger_operator.called
+    assert "Trigger DAG for stanford" in caplog.text


### PR DESCRIPTION
Fixes #183 

Part of refactoring to use a single SQS queue for all groups in Sinopia instead of each institution having it's own queue. 