### PR TITLE
Institutional DAGs support for Single all-institutions SQS queue

### DIFF
--- a/ils_middleware/tasks/general/init.py
+++ b/ils_middleware/tasks/general/init.py
@@ -1,0 +1,20 @@
+from airflow.operators.python import get_current_context
+
+
+def message_from_context(**kwargs):
+    """
+    Retrieves messages from context
+    """
+    context = kwargs.get("context")
+
+    if context is None:
+        context = get_current_context()
+
+    params = context.get("params")
+
+    message = params.get("message")
+
+    if message is None:
+        raise ValueError("Cannot initialize DAG, no message present")
+
+    return message

--- a/tests/helpers/tasks.py
+++ b/tests/helpers/tasks.py
@@ -277,6 +277,8 @@ def mock_task_instance(monkeypatch, tmp_path):
                 "https://api.development.sinopia.io/resource/0000-1111-2222-3333",
                 "https://api.development.sinopia.io/resource/4444-5555-6666-7777",
             ]
+        elif task_ids == "get-message-from-context":
+            return json.loads(mock_message()[0]["Body"])
         elif key == "messages":
             return mock_message()
         elif key in mock_resources and task_ids == "sqs-message-parse":

--- a/tests/tasks/general/test_init.py
+++ b/tests/tasks/general/test_init.py
@@ -1,0 +1,21 @@
+import pytest
+
+from ils_middleware.tasks.general.init import message_from_context
+
+
+def test_message_from_context():
+    mock_context = {
+        "params": {
+            "message": {"resource": {"http://sinopia.io/resources/1111-2222-3333-0000"}}
+        }
+    }
+
+    message = message_from_context(context=mock_context)
+
+    assert message == {"resource": {"http://sinopia.io/resources/1111-2222-3333-0000"}}
+
+
+def test_message_from_context_no_message():
+    mock_context = {"params": {"message": None}}
+    with pytest.raises(ValueError, match="Cannot initialize DAG, no message present"):
+        message_from_context(context=mock_context)


### PR DESCRIPTION
Individual FOLIO and Alma institutional DAGs now support single `all-institutions` SQS queue that is triggered by the `monitor_institutions_messages` DAG.