### PR TITLE
Removes use of temp folders for Alma DAGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Based on the documentation, [Running Airflow in Docker](https://airflow.apache.o
 AWS_ACCESS_KEY_ID=999999 AWS_SECRET_ACCESS_KEY=1231 aws sqs \
     --endpoint-url=http://localhost:4566 create-queue \
     --region us-west-2 \
-    --queue-name stanford-ils
+    --queue-name all-instituions
 ```
 
 ### Setup the local AWS connection for SQS
@@ -46,7 +46,7 @@ In order to test a dag locally, a message must be sent to the above queue:
 AWS_ACCESS_KEY_ID=999999 AWS_SECRET_ACCESS_KEY=1231 aws sqs \
     send-message \
     --endpoint-url=http://localhost:4566 \
-    --queue-url https://localhost:4566/000000000000/stanford-ils \
+    --queue-url https://localhost:4566/000000000000/all-institutions \
     --message-body file://tests/fixtures/sqs/test-message.json
 ```
 


### PR DESCRIPTION
The most significant update in this PR was re-writing how Alma DAGs were using temp folders, to that end many of the processes that relied on temporary folders are now removed. 

Minor changes to the XSL folders were added based on the needs from the Alma focus group libraries and ILS processing.