### PR TITLE
Use empty list if failed_resources is None

### DIFF
--- a/ils_middleware/tasks/sinopia/email.py
+++ b/ils_middleware/tasks/sinopia/email.py
@@ -50,7 +50,7 @@ def send_task_failure_notifications(**kwargs) -> None:
     failed_resources = task_instance.xcom_pull(
         key="conversion_failures", task_ids="process_symphony.rdf2marc"
     )
-    for resource_uri in failed_resources:
+    for resource_uri in failed_resources or []:
         message = task_instance.xcom_pull(
             key=resource_uri, task_ids="sqs-message-parse"
         )


### PR DESCRIPTION
From this [error](https://airflow.stage.sinopia.io/dags/stanford/grid?run_id=manual__2024-09-12T19%3A23%3A13.837134%2B00%3A00&execution_date=2024-09-12+19%3A23%3A13.837134%2B00%3A00&tab=logs&dag_run_id=manual__2024-09-12T19%3A23%3A13.837134%2B00%3A00&task_id=sinopia_update_notification) when running DAG