### PR TITLE
Update bf_work.py - update contributor (person) mapping

### DIFF
--- a/ils_middleware/tasks/folio/mappings/bf_work.py
+++ b/ils_middleware/tasks/folio/mappings/bf_work.py
@@ -7,16 +7,15 @@ PREFIX bflc: <http://id.loc.gov/ontologies/bflc/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 
-SELECT ?agent ?role
+SELECT ?primary_contribution ?role
 WHERE {{
-    <{bf_work}> a bf:Work .
-    <{bf_work}> bf:contribution ?contrib_bnode .
-    ?contrib_bnode a bf:Contribution .
-    ?contrib_bnode bf:role ?role_uri .
-    ?role_uri rdfs:label ?role .
-    ?contrib_bnode bf:agent ?agent_uri .
-    ?agent_uri a {bf_class} .
-    ?agent_uri rdfs:label ?agent .
+    <{bf_work}> a bf:Work ;
+        bf:contribution ?contribution . 
+    ?contribution bf:agent ?primarycontribution .
+    ?primarycontribution a bf:Person .
+    ?primarycontribution rdfs:label ?primary_contribution .
+    ?contribution bf:role ?type .
+    ?type rdfs:label ?role
 }}
 """
 


### PR DESCRIPTION
Attempting to update the FOLIO Work mapping for the contributor type - person. Do not see a way to differentiate between person and organization here, or if I need to. I did not add the query for contributor type - organization yet. Testing this out as a first step.