### PR TITLE
Update bf_work.py bf class for Primary Contribution

### DIFF
--- a/ils_middleware/tasks/folio/mappings/bf_work.py
+++ b/ils_middleware/tasks/folio/mappings/bf_work.py
@@ -11,7 +11,7 @@ SELECT ?agent ?role
 WHERE {{
     <{bf_work}> a bf:Work .
     <{bf_work}> bf:contribution ?contrib_bnode .
-    ?contrib_bnode a bf:Contribution .
+    ?contrib_bnode a bf:PrimaryContribution .
     ?contrib_bnode bf:role ?role_uri .
     ?role_uri rdfs:label ?role .
     ?contrib_bnode bf:agent ?agent_uri .


### PR DESCRIPTION
Export from Sinopia to FOLIO failed. Error " Failed to execute job 787321 for task process_folio.build-folio ('author'; 5210)" on DAG run manual__2025-06-02T17:25:21.090386+00:00. I noticed that the SPARQL for Primary Contribution was still using the bf:Contribution class in line 14. I updated it to reflect the Blue Core template, bf:PrimaryContribution. The last update to accommodate this change only updated the namespace but no the SPARQL.