### PR TITLE
Update map.py

### DIFF
--- a/ils_middleware/tasks/folio/map.py
+++ b/ils_middleware/tasks/folio/map.py
@@ -15,7 +15,7 @@ BF_TO_FOLIO_MAP = {
         "uri": "work",
         "class": "bf:Person",
     },
-    "editions": {"template": bf_work_map.editions, "uri": "work"},
+    "editions": {"template": bf_instance_map.editions, "uri": "instance"},
     "instance_format": {
         "template": bf_instance_map.instance_format_id,
         "uri": "instance",


### PR DESCRIPTION
Updates map.py to look for editions in bf_instance_map as a result recent changes; humble attempt to resolve error in #291  "ils_middleware/tasks/folio/map.py:18: error: Module has no attribute "editions"  [attr-defined]"